### PR TITLE
CVE-2020-28469-Patch - Upgraded glob-parent to 5.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "express": "^4.17.1",
     "express-nunjucks": "^2.2.5",
     "express-session": "^1.17.2",
+    "glob-parent": "5.1.2",
     "govuk-frontend": "^3.9.1",
     "helmet": "^4.6.0",
     "jest-when": "^3.3.1",
@@ -121,5 +122,8 @@
     "webpack-cli": "^3.3.11",
     "webpack-dev-middleware": "^5.0.0",
     "webpack-node-externals": "^1.7.2"
+  },
+  "resolutions": {
+    "express-nunjucks/nunjucks-async-loader/chokidar/glob-parent": "5.1.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5303,6 +5303,13 @@ gherkin@5.0.0:
   resolved "https://registry.yarnpkg.com/gherkin/-/gherkin-5.0.0.tgz#96def41198ec3908258b511af74f655a2764d2a1"
   integrity sha1-lt70EZjsOQgli1Ea909lWidk0qE=
 
+glob-parent@5.1.2, glob-parent@~5.1.0:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
+  integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
+  dependencies:
+    is-glob "^4.0.1"
+
 glob-parent@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-3.1.0.tgz#9e6af6299d8d3bd2bd40430832bd113df906c5ae"
@@ -5311,7 +5318,7 @@ glob-parent@^3.1.0:
     is-glob "^3.1.0"
     path-dirname "^1.0.0"
 
-glob-parent@^5.0.0, glob-parent@^5.1.0, glob-parent@^5.1.1, glob-parent@~5.1.0:
+glob-parent@^5.0.0, glob-parent@^5.1.0, glob-parent@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.1.tgz#b6c1ef417c4e5663ea498f1c45afac6916bbc229"
   integrity sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==


### PR DESCRIPTION
### Change description ###
Set express-nunjucks to resolve underlying dependencies to using glob-parent 5.1.2. CVE-2020-28469 - https://nvd.nist.gov/vuln/detail/CVE-2020-28469


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
