### PR TITLE
CVE-2020-28499-patch - Upgraded merge to 2.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "webpack-node-externals": "^1.7.2"
   },
   "resolutions": {
-    "express-nunjucks/nunjucks-async-loader/chokidar/glob-parent": "5.1.2"
+    "express-nunjucks/nunjucks-async-loader/chokidar/glob-parent": "5.1.2",
+    "sass-lint/merge": "^2.1.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7282,10 +7282,10 @@ merge2@^1.3.0:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
-merge@^1.2.0:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.1.tgz#38bebf80c3220a8a487b6fcfb3941bb11720c145"
-  integrity sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==
+merge@^1.2.0, merge@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/merge/-/merge-2.1.1.tgz#59ef4bf7e0b3e879186436e8481c06a6c162ca98"
+  integrity sha512-jz+Cfrg9GWOZbQAnDQ4hlVnQky+341Yk5ru8bZSe6sIDTCIg8n9i/u7hSQGSVOF3C7lH6mGtqjkiT9G4wFLL0w==
 
 methods@^1.1.2, methods@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
### Change description ###

Upgraded sass-lint dependent merge to 2.1.1 due to CVE-2020-28499

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
