### PR TITLE
FACT-539 - Prevent duplicated opening hours types being adding to admin portal

### DIFF
--- a/cucumber.js
+++ b/cucumber.js
@@ -1,5 +1,5 @@
 let common = [
-  'src/test/functional/features/opening-hours.feature',
+  'src/test/functional/features/*.feature',
   '--require-module ts-node/register',
   '--require src/test/functional/**/*.ts',
   '--tags "not @skipped and not @pending"',

--- a/cucumber.js
+++ b/cucumber.js
@@ -1,5 +1,5 @@
 let common = [
-  'src/test/functional/features/*.feature',
+  'src/test/functional/features/opening-hours.feature',
   '--require-module ts-node/register',
   '--require src/test/functional/**/*.ts',
   '--tags "not @skipped and not @pending"',

--- a/src/main/app/controller/courts/OpeningTimesController.ts
+++ b/src/main/app/controller/courts/OpeningTimesController.ts
@@ -15,7 +15,7 @@ export class OpeningTimesController {
   openingTimeDuplicatedErrorMsg = 'All descriptions must be unique.';
   getOpeningTimesErrorMsg = 'A problem occurred when retrieving the opening times.';
   getOpeningTypesErrorMsg = 'A problem occurred when retrieving the opening time descriptions.';
-  private updateErrorMsg = 'A problem occurred when saving the opening times.';
+  updateErrorMsg = 'A problem occurred when saving the opening times.';
 
   public async get(
     req: AuthedRequest,

--- a/src/main/types/Error.ts
+++ b/src/main/types/Error.ts
@@ -1,0 +1,3 @@
+export interface Error {
+  text: String
+}

--- a/src/main/types/OpeningTime.ts
+++ b/src/main/types/OpeningTime.ts
@@ -1,14 +1,16 @@
 import {SelectItem} from "./CourtPageData";
+import {Error} from "./Error";
 
 export interface OpeningTime {
   type_id: number,
   hours: string,
-  isNew?: boolean
+  isNew?: boolean,
+  isDuplicated?: boolean
 }
 
 export interface OpeningTimeData {
   opening_times: OpeningTime[],
   openingTimeTypes: SelectItem[],
-  errorMsg: string,
+  errors: Error[],
   updated: boolean
 }

--- a/src/main/utils/validation.ts
+++ b/src/main/utils/validation.ts
@@ -1,3 +1,5 @@
+import {OpeningTime} from '../types/OpeningTime';
+
 export const isObjectEmpty = (obj: {}): boolean => {
   return Object.keys(obj).length === 0;
 };
@@ -5,4 +7,18 @@ export const isObjectEmpty = (obj: {}): boolean => {
 export function validateEmail(email: string): boolean {
   const regexp = new RegExp(/^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/);
   return regexp.test(email);
+}
+
+export function validateOpeningTimeDuplicates(openingHours: OpeningTime[]): boolean {
+  let hasDuplicates = false;
+  for (let i = 0; i < openingHours.length - 1; i++) {
+    for (let j = i + 1; j < openingHours.length; j++) {
+      if (openingHours[i].type_id && openingHours[i].type_id === openingHours[j].type_id) {
+        openingHours[i].isDuplicated = true;
+        openingHours[j].isDuplicated = true;
+        hasDuplicates = true;
+      }
+    }
+  }
+  return !hasDuplicates;
 }

--- a/src/main/views/courts/tabs/openingHoursContent.njk
+++ b/src/main/views/courts/tabs/openingHoursContent.njk
@@ -18,14 +18,10 @@
     target='_blank' rel='noopener noreferrer'>times</a> "})
 }}
 
-{% if errorMsg != '' %}
+{% if errors|length %}
   {{ govukErrorSummary({
     titleText: "There is a problem",
-    errorList: [
-      {
-        text: errorMsg
-      }
-    ]
+    errorList: errors
   }) }}
 {% endif %}
 
@@ -41,7 +37,9 @@
 
   {% set descriptionError = false %}
   {% if openingTime.type_id === '' %}
-    {% set descriptionError = { text: 'Type is required' } %}
+    {% set descriptionError = { text: 'Description is required' } %}
+  {% elif openingTime.isDuplicated === true %}
+    {% set descriptionError = { text: 'Duplicated description' } %}
   {% endif %}
 
   {% set hoursError = false %}
@@ -62,7 +60,7 @@
     id: "opening_times-" + loop.index,
     name: "opening_times[" + loop.index +"][type_id]",
     label: {
-      text: "Type"
+      text: "Description"
     },
     errorMessage: descriptionError,
     items: openingTimeTypes | selectFilter(openingTime.type_id)
@@ -86,9 +84,7 @@
       type: "button",
       classes: "govuk-button--secondary deleteOpeningTime"
     }) }}
-  {% endif %}
-
-  {% if isNew === true %}
+  {% else %}
     {{ govukButton({
       text: "Clear",
       name: "clearOpeningTime",

--- a/src/test/functional/features/opening-hours.feature
+++ b/src/test/functional/features/opening-hours.feature
@@ -21,11 +21,6 @@ Feature: Opening Hours
     Then the second last opening time is displayed as expected with type shown as selected index 4 and hours as "9:00am to 3:30pm"
     And the last opening time is displayed as expected with type shown as selected index 5 and hours as "10:00am to 4:00pm"
 
-  Scenario: Prevent incomplete entries being added
-    When I enter an incomplete opening hours entry
-    And I click save
-    Then an error message is displayed
-
   Scenario: Remove opening hours
     When I click the remove button under an opening hours entry
     Then I click save
@@ -33,3 +28,13 @@ Feature: Opening Hours
     When I click the remove button under an opening hours entry
     Then I click save
     Then a green update message is displayed in the opening hours tab
+
+  Scenario: Prevent incomplete entries being added
+    When I enter an incomplete opening hour description
+    And I click save
+    Then An error is displayed for opening hours with summary "Description and hours are required for all opening times." and description field message "Description is required"
+
+  Scenario: Prevent duplicated entries being added
+    When I enter duplicated opening hour description
+    And I click save
+    Then An error is displayed for opening hours with summary "All descriptions must be unique." and description field message "Duplicated description"

--- a/src/test/functional/features/opening-hours.feature
+++ b/src/test/functional/features/opening-hours.feature
@@ -13,6 +13,9 @@ Feature: Opening Hours
     Then I can view the existing opening hours
 
   Scenario: Add opening hours
+    # Clear out potential left-over opening hours from the previous run before adding new ones
+    When I remove all existing opening hours entries and save
+    Then a green update message is displayed in the opening hours tab
     When I enter new opening hours entry by selecting type at index 4 and adding text "9:00am to 3:30pm"
     Then I click the Add button in the opening hours tab
     And I enter new opening hours entry by selecting type at index 5 and adding text "10:00am to 4:00pm"

--- a/src/test/functional/steps/opening-hours.ts
+++ b/src/test/functional/steps/opening-hours.ts
@@ -19,6 +19,11 @@ Then('I can view the existing opening hours', async () => {
   expect(tabClosed).equal(false);
 });
 
+When('I remove all existing opening hours entries and save', async () => {
+  await FunctionalTestHelpers.clearFieldsets('#openingTimesTab', 'deleteOpeningHours');
+  await FunctionalTestHelpers.clickSaveButton('#openingTimesTab', 'saveOpeningTime');
+});
+
 When('I enter new opening hours entry by selecting type at index {int} and adding text {string}', async (typeIdx: number, text: string) => {
   const numFieldsets = await I.countElement('#openingTimesTab fieldset');
   const entryFormIdx = numFieldsets - 2;
@@ -40,10 +45,7 @@ When('I click the Add button in the opening hours tab', async () => {
 });
 
 Then('I click save', async () => {
-  const selector = '#openingTimesTab button[name="saveOpeningTime"]';
-  const elementExist = await I.checkElement(selector);
-  expect(elementExist).equal(true);
-  await I.click(selector);
+  await FunctionalTestHelpers.clickSaveButton('#openingTimesTab', 'saveOpeningTime');
 });
 
 Then('a green update message is displayed in the opening hours tab', async () => {

--- a/src/test/functional/steps/opening-hours.ts
+++ b/src/test/functional/steps/opening-hours.ts
@@ -20,8 +20,7 @@ Then('I can view the existing opening hours', async () => {
 });
 
 When('I remove all existing opening hours entries and save', async () => {
-  await FunctionalTestHelpers.clearFieldsets('#openingTimesTab', 'deleteOpeningHours');
-  await FunctionalTestHelpers.clickSaveButton('#openingTimesTab', 'saveOpeningTime');
+  await FunctionalTestHelpers.clearFieldsets('#openingTimesTab', 'deleteOpeningHours', 'saveOpeningTime');
 });
 
 When('I enter new opening hours entry by selecting type at index {int} and adding text {string}', async (typeIdx: number, text: string) => {

--- a/src/test/functional/steps/opening-hours.ts
+++ b/src/test/functional/steps/opening-hours.ts
@@ -75,7 +75,7 @@ Then('the last opening time is displayed as expected with type shown as selected
   expect(hours).equal(hoursText);
 });
 
-When('I enter an incomplete opening hours entry', async () => {
+When('I enter an incomplete opening hour description', async () => {
   const numFieldsets = await I.countElement('#openingTimesTab fieldset');
   const entryFormIdx = numFieldsets - 2; // we deduct one each for zero-based index and hidden template field
 
@@ -86,9 +86,40 @@ When('I enter an incomplete opening hours entry', async () => {
   await I.setElementValueAtIndex('#openingTimesTab input[name$="[hours]"', entryFormIdx, '10:00am to 4:00pm', 'input');
 });
 
-Then('an error message is displayed', async () => {
-  const elementExist = await I.checkElement('#openingTimesTab .govuk-error-summary');
-  expect(elementExist).equal(true);
+When('I enter duplicated opening hour description', async () => {
+  const numFieldsets = await I.countElement('#openingTimesTab fieldset');
+  const entryFormIdx = numFieldsets - 2; // we deduct one each for zero-based index and hidden template field
+
+  const typeSelector = '#openingTimesTab select[name$="[type_id]"]';
+  const hoursSelector = '#openingTimesTab input[name$="[hours]"]';
+
+  await I.setElementValueAtIndex(typeSelector, entryFormIdx, 3, 'select');
+  await I.setElementValueAtIndex(hoursSelector, entryFormIdx, '9:00am to 4:00pm', 'input');
+
+  await I.setElementValueAtIndex(typeSelector, entryFormIdx + 1, 3, 'select');
+  await I.setElementValueAtIndex(hoursSelector, entryFormIdx + 1, '10:00am to 5:00pm', 'input');
+});
+
+Then('An error is displayed for opening hours with summary {string} and description field message {string}', async (summary: string, message: string) => {
+  const errorTitle = 'There is a problem';
+  let selector = '#error-summary-title';
+  expect(await I.checkElement(selector)).equal(true);
+  const errorTitleElement = await I.getElement(selector);
+  expect(await I.getElementText(errorTitleElement)).equal(errorTitle);
+
+  selector = '#openingTimesContent > div > div > ul > li';
+  expect(await I.checkElement(selector)).equal(true);
+  const errorListElement = await I.getElement(selector);
+  expect(await I.getElementText(errorListElement)).equal(summary);
+
+  const numFieldsets = await I.countElement('#openingTimesTab fieldset');
+  const fieldsetErrorIndex = numFieldsets - 1;  // The last field set is the hidden template fieldset
+  selector = '#opening_times-' + fieldsetErrorIndex + '-error';
+  expect(await I.checkElement(selector)).equal(true);
+  const descriptionErrorElement = await I.getElement(selector);
+  expect(await I.getElementText(descriptionErrorElement)).contains(message);
+
+  expect(await I.checkElement('#hours-' + fieldsetErrorIndex + '-error')).equal(false);
 });
 
 When('I click the remove button under an opening hours entry', async () => {

--- a/src/test/functional/steps/opening-hours.ts
+++ b/src/test/functional/steps/opening-hours.ts
@@ -20,7 +20,7 @@ Then('I can view the existing opening hours', async () => {
 });
 
 When('I remove all existing opening hours entries and save', async () => {
-  await FunctionalTestHelpers.clearFieldsets('#openingTimesTab', 'deleteOpeningHours', 'saveOpeningTime');
+  await FunctionalTestHelpers.clearFieldsetsAndSave('#openingTimesTab', 'deleteOpeningHours', 'saveOpeningTime');
 });
 
 When('I enter new opening hours entry by selecting type at index {int} and adding text {string}', async (typeIdx: number, text: string) => {
@@ -44,7 +44,7 @@ When('I click the Add button in the opening hours tab', async () => {
 });
 
 Then('I click save', async () => {
-  await FunctionalTestHelpers.save('#openingTimesTab', 'saveOpeningTime');
+  await FunctionalTestHelpers.clickButton('#openingTimesTab', 'saveOpeningTime');
 });
 
 Then('a green update message is displayed in the opening hours tab', async () => {
@@ -125,11 +125,7 @@ Then('An error is displayed for opening hours with summary {string} and descript
 
 When('I click the remove button under an opening hours entry', async () => {
   const numOpeningTimes = await I.countElement('#openingTimesTab fieldset');
-
-  const selector = '#openingTimesTab button[name="deleteOpeningHours"]';
-  const elementExist = await I.checkElement(selector);
-  expect(elementExist).equal(true);
-  await I.click(selector);
+  await FunctionalTestHelpers.clickButton('#openingTimesTab', 'deleteOpeningHours');
 
   const updatedNumOpeningTimes = await I.countElement('#openingTimesTab fieldset');
   expect(numOpeningTimes - updatedNumOpeningTimes).equal(1);

--- a/src/test/functional/steps/opening-hours.ts
+++ b/src/test/functional/steps/opening-hours.ts
@@ -44,7 +44,7 @@ When('I click the Add button in the opening hours tab', async () => {
 });
 
 Then('I click save', async () => {
-  await FunctionalTestHelpers.clickSaveButton('#openingTimesTab', 'saveOpeningTime');
+  await FunctionalTestHelpers.save('#openingTimesTab', 'saveOpeningTime');
 });
 
 Then('a green update message is displayed in the opening hours tab', async () => {

--- a/src/test/functional/utlis/helpers.ts
+++ b/src/test/functional/utlis/helpers.ts
@@ -6,33 +6,25 @@ export class FunctionalTestHelpers {
   public static async clickButtonAndCheckFieldsetAdded(containerId: string, buttonName: string, fieldsetClass = '') {
     const fieldsetSelector = `${containerId} fieldset${fieldsetClass}`;
     const numFieldsets = await I.countElement(fieldsetSelector);
-
-    const selector = `button[name="${buttonName}"]`;
-    const elementExist = await I.checkElement(selector);
-    expect(elementExist).equal(true);
-    await I.click(selector);
+    await this.clickButton(containerId, buttonName);
 
     const updatedNumFieldsets = await I.countElement(fieldsetSelector);
     expect(updatedNumFieldsets - numFieldsets).equal(1);
   }
 
-  public static async clearFieldsets(containerId: string, deleteButtonName: string, saveButtonName: string) {
+  public static async clearFieldsetsAndSave(containerId: string, deleteButtonName: string, saveButtonName: string) {
     const fieldsetSelector = `${containerId} fieldset`;
     const fieldsetCount = await I.countElement(fieldsetSelector);
     // Remove all fieldsets except the empty new one and the template
     for (let i = fieldsetCount; i > 2; i--) {
-      const deleteButtonSelector = `${containerId} button[name="${deleteButtonName}"]`;
-      const elementExist = await I.checkElement(deleteButtonSelector);
-      expect(elementExist).equal(true);
-      await I.click(deleteButtonSelector);
-
+      await this.clickButton(containerId, deleteButtonName);
       const updatedFieldsetCount = await I.countElement(fieldsetSelector);
       expect(i - updatedFieldsetCount).equal(1);
     }
-    await this.save(containerId, saveButtonName);
+    await this.clickButton(containerId, saveButtonName);
   }
 
-  public static async save(containerId: string, buttonName: string) {
+  public static async clickButton(containerId: string, buttonName: string) {
     const selector = `${containerId} button[name="${buttonName}"]`;
     const elementExist = await I.checkElement(selector);
     expect(elementExist).equal(true);

--- a/src/test/functional/utlis/helpers.ts
+++ b/src/test/functional/utlis/helpers.ts
@@ -29,10 +29,10 @@ export class FunctionalTestHelpers {
       const updatedFieldsetCount = await I.countElement(fieldsetSelector);
       expect(i - updatedFieldsetCount).equal(1);
     }
-    await this.clickSaveButton(containerId, saveButtonName);
+    await this.save(containerId, saveButtonName);
   }
 
-  public static async clickSaveButton(containerId: string, buttonName: string) {
+  public static async save(containerId: string, buttonName: string) {
     const selector = `${containerId} button[name="${buttonName}"]`;
     const elementExist = await I.checkElement(selector);
     expect(elementExist).equal(true);

--- a/src/test/functional/utlis/helpers.ts
+++ b/src/test/functional/utlis/helpers.ts
@@ -16,12 +16,12 @@ export class FunctionalTestHelpers {
     expect(updatedNumFieldsets - numFieldsets).equal(1);
   }
 
-  public static async clearFieldsets(containerId: string, buttonName: string) {
+  public static async clearFieldsets(containerId: string, deleteButtonName: string, saveButtonName: string) {
     const fieldsetSelector = `${containerId} fieldset`;
     const fieldsetCount = await I.countElement(fieldsetSelector);
     // Remove all fieldsets except the empty new one and the template
     for (let i = fieldsetCount; i > 2; i--) {
-      const deleteButtonSelector = `${containerId} button[name="${buttonName}"]`;
+      const deleteButtonSelector = `${containerId} button[name="${deleteButtonName}"]`;
       const elementExist = await I.checkElement(deleteButtonSelector);
       expect(elementExist).equal(true);
       await I.click(deleteButtonSelector);
@@ -29,6 +29,7 @@ export class FunctionalTestHelpers {
       const updatedFieldsetCount = await I.countElement(fieldsetSelector);
       expect(i - updatedFieldsetCount).equal(1);
     }
+    await this.clickSaveButton(containerId, saveButtonName);
   }
 
   public static async clickSaveButton(containerId: string, buttonName: string) {

--- a/src/test/functional/utlis/helpers.ts
+++ b/src/test/functional/utlis/helpers.ts
@@ -15,4 +15,26 @@ export class FunctionalTestHelpers {
     const updatedNumFieldsets = await I.countElement(fieldsetSelector);
     expect(updatedNumFieldsets - numFieldsets).equal(1);
   }
+
+  public static async clearFieldsets(containerId: string, buttonName: string) {
+    const fieldsetSelector = `${containerId} fieldset`;
+    const fieldsetCount = await I.countElement(fieldsetSelector);
+    // Remove all fieldsets except the empty new one and the template
+    for (let i = fieldsetCount; i > 2; i--) {
+      const deleteButtonSelector = `${containerId} button[name="${buttonName}"]`;
+      const elementExist = await I.checkElement(deleteButtonSelector);
+      expect(elementExist).equal(true);
+      await I.click(deleteButtonSelector);
+
+      const updatedFieldsetCount = await I.countElement(fieldsetSelector);
+      expect(i - updatedFieldsetCount).equal(1);
+    }
+  }
+
+  public static async clickSaveButton(containerId: string, buttonName: string) {
+    const selector = `${containerId} button[name="${buttonName}"]`;
+    const elementExist = await I.checkElement(selector);
+    expect(elementExist).equal(true);
+    await I.click(selector);
+  }
 }

--- a/src/test/unit/app/controller/courts/OpeningTimesController.ts
+++ b/src/test/unit/app/controller/courts/OpeningTimesController.ts
@@ -67,7 +67,7 @@ describe('OpeningTimesController', () => {
       'opening_times': expectedOpeningTimes,
       openingTimeTypes: expectedSelectItems,
       updated: false,
-      errorMsg: ''
+      errors: []
     };
     expect(res.render).toBeCalledWith('courts/tabs/openingHoursContent', expectedResults);
   });
@@ -113,6 +113,23 @@ describe('OpeningTimesController', () => {
     expect(mockApi.updateOpeningTimes).not.toBeCalled();
   });
 
+  test('Should not post opening times if descriptions are duplicated', async() => {
+    const slug = 'another-county-court';
+    const res = mockResponse();
+    const req = mockRequest();
+    const postedOpeningTimes: OpeningTime[] = getOpeningTimes().concat([{ 'type_id': 2, hours: '10am to 5pm', isNew: true }]);
+    req.body = {
+      'opening_times': postedOpeningTimes,
+      '_csrf': CSRF.create()
+    };
+    req.params = { slug: slug };
+    req.scope.cradle.api = mockApi;
+    req.scope.cradle.api.updateOpeningTimes = jest.fn().mockReturnValue(res);
+
+    await controller.put(req, res);
+    expect(mockApi.updateOpeningTimes).not.toBeCalled();
+  });
+
   test('Should not post opening times if CSRF token is invalid', async() => {
     const slug = 'another-county-court';
     const res = mockResponse();
@@ -135,7 +152,7 @@ describe('OpeningTimesController', () => {
       'opening_times': postedOpeningTimes,
       openingTimeTypes: expectedSelectItems,
       updated: false,
-      errorMsg: 'A problem occurred when saving the opening times.'
+      errors: [{text: 'A problem occurred when saving the opening times.'}]
     };
 
     await controller.put(req, res);
@@ -160,7 +177,7 @@ describe('OpeningTimesController', () => {
       'opening_times': null,
       openingTimeTypes: expectedSelectItems,
       updated: false,
-      errorMsg: controller.getOpeningTimesErrorMsg
+      errors: [{text: controller.getOpeningTimesErrorMsg}]
     };
     expect(res.render).toBeCalledWith('courts/tabs/openingHoursContent', expectedResults);
   });
@@ -183,7 +200,58 @@ describe('OpeningTimesController', () => {
       'opening_times': expectedOpeningTimes,
       openingTimeTypes: [],
       updated: false,
-      errorMsg: controller.getOpeningTypesErrorMsg
+      errors: [{text: controller.getOpeningTypesErrorMsg}]
+    };
+    expect(res.render).toBeCalledWith('courts/tabs/openingHoursContent', expectedResults);
+  });
+
+  test('Should handle error with duplicated descriptions when updating opening time', async () => {
+    const req = mockRequest();
+    const postedOpeningTimes: OpeningTime[] = getOpeningTimes().concat([{ 'type_id': 2, hours: '10am to 5pm', isNew: true }]);
+    req.params = { slug: 'southport-county-court' };
+    req.body = {
+      'opening_times': postedOpeningTimes,
+      '_csrf': CSRF.create()
+    };
+    req.scope.cradle.api = mockApi;
+    req.scope.cradle.api.updateOpeningTimes = jest.fn().mockRejectedValue(new Error('Mock API Error'));
+    const res = mockResponse();
+
+    await controller.put(req, res);
+
+    const expectedResults: OpeningTimeData = {
+      'opening_times': postedOpeningTimes,
+      openingTimeTypes: expectedSelectItems,
+      updated: false,
+      errors: [{text: controller.openingTimeDuplicatedErrorMsg}]
+    };
+    expect(res.render).toBeCalledWith('courts/tabs/openingHoursContent', expectedResults);
+  });
+
+  test('Should handle multiple errors when updating opening time', async () => {
+    const req = mockRequest();
+    const postedOpeningTimes: OpeningTime[] = getOpeningTimes()
+      .concat([{ 'type_id': 2, hours: '10am to 5pm', isNew: true }])
+      .concat([{ 'type_id': 1, hours: '', isNew: true }]);
+    req.params = { slug: 'southport-county-court' };
+    req.body = {
+      'opening_times': postedOpeningTimes,
+      '_csrf': CSRF.create()
+    };
+    req.scope.cradle.api = mockApi;
+    req.scope.cradle.api.updateOpeningTimes = jest.fn().mockRejectedValue(new Error('Mock API Error'));
+    const res = mockResponse();
+
+    await controller.put(req, res);
+
+    const expectedResults: OpeningTimeData = {
+      'opening_times': postedOpeningTimes,
+      openingTimeTypes: expectedSelectItems,
+      updated: false,
+      errors: [
+        {text: controller.emptyTypeOrHoursErrorMsg},
+        {text: controller.openingTimeDuplicatedErrorMsg}
+      ]
     };
     expect(res.render).toBeCalledWith('courts/tabs/openingHoursContent', expectedResults);
   });

--- a/src/test/unit/app/controller/courts/OpeningTimesController.ts
+++ b/src/test/unit/app/controller/courts/OpeningTimesController.ts
@@ -152,7 +152,7 @@ describe('OpeningTimesController', () => {
       'opening_times': postedOpeningTimes,
       openingTimeTypes: expectedSelectItems,
       updated: false,
-      errors: [{text: 'A problem occurred when saving the opening times.'}]
+      errors: [{text: controller.updateErrorMsg}]
     };
 
     await controller.put(req, res);


### PR DESCRIPTION
### JIRA link ###

https://tools.hmcts.net/jira/browse/FACT-539

### Change description ###

- Prevent duplicated opening hours types being adding to admin portal
- Add the ability to return multiple errors in error summary

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
