### PR TITLE
FACT-541 Prevent duplicated e-mail addresses on admin portal email tab

### DIFF
--- a/cucumber.js
+++ b/cucumber.js
@@ -1,5 +1,5 @@
 let common = [
-  'src/test/functional/features/*.feature',
+  'src/test/functional/features/email-addresses.feature',
   '--require-module ts-node/register',
   '--require src/test/functional/**/*.ts',
   '--tags "not @skipped and not @pending"',

--- a/cucumber.js
+++ b/cucumber.js
@@ -1,5 +1,5 @@
 let common = [
-  'src/test/functional/features/email-addresses.feature',
+  'src/test/functional/features/*.feature',
   '--require-module ts-node/register',
   '--require src/test/functional/**/*.ts',
   '--tags "not @skipped and not @pending"',

--- a/src/main/app/controller/courts/EmailsController.ts
+++ b/src/main/app/controller/courts/EmailsController.ts
@@ -4,23 +4,25 @@ import {Response} from 'express';
 import {SelectItem} from '../../../types/CourtPageData';
 import {Email, EmailData} from '../../../types/Email';
 import {EmailType} from '../../../types/EmailType';
-import {validateEmail} from '../../../utils/validation';
+import {validateDuplication, validateEmailFormat} from '../../../utils/validation';
 import {CSRF} from '../../../modules/csrf';
+import {Error} from '../../../types/Error';
 
 @autobind
 export class EmailsController {
 
-  private emptyTypeOrAddressErrorMsg = 'Type and address are required for all emails.';
-  private updateErrorMsg = 'A problem occurred when saving the emails.';
+  emptyTypeOrAddressErrorMsg = 'Description and address are required for all emails.';
+  updateErrorMsg = 'A problem occurred when saving the emails.';
+  emailDuplicatedErrorMsg = 'All email addresses must be unique.'
   getEmailsErrorMsg = 'A problem occurred when retrieving the emails.';
-  getEmailTypesErrorMsg = 'A problem occurred when retrieving the email types.';
+  getEmailTypesErrorMsg = 'A problem occurred when retrieving the email descriptions.';
   getEmailAddressFormatErrorMsg = 'Enter an email address in the correct format, like name@example.com';
 
   public async get(
     req: AuthedRequest,
     res: Response,
     updated = false,
-    error = '',
+    errorMsg: string[] = [],
     emails: Email[] = null): Promise<void> {
 
     const slug: string = req.params.slug as string;
@@ -29,22 +31,27 @@ export class EmailsController {
       // Get emails from API and set the isNew property to false on all email entries.
       await req.scope.cradle.api.getEmails(slug)
         .then((value: Email[]) => emails = value.map(e => { e.isNew = false; return e; }))
-        .catch(() => error += this.getEmailsErrorMsg);
+        .catch(() => errorMsg.push(this.getEmailsErrorMsg));
     }
 
     let types: EmailType[] = [];
     await req.scope.cradle.api.getEmailTypes()
       .then((value: EmailType[]) => types = value)
-      .catch(() => error += this.getEmailTypesErrorMsg);
+      .catch(() => errorMsg.push(this.getEmailTypesErrorMsg));
 
     if (!emails?.some(e => e.isNew === true)) {
       this.addEmptyFormsForNewEntries(emails);
     }
 
+    const errors: Error[] = [];
+    for (const msg of errorMsg) {
+      errors.push({text: msg});
+    }
+
     const pageData: EmailData = {
       'emails': emails,
       emailTypes: EmailsController.getEmailTypesForSelect(types),
-      errorMsg: error,
+      errors: errors,
       updated: updated
     };
     res.render('courts/tabs/emailsContent', pageData);
@@ -54,26 +61,21 @@ export class EmailsController {
     let emails = req.body.emails as Email[] ?? [];
     emails.forEach(e => e.isNew = (e.isNew === true) || ((e.isNew as any) === 'true'));
 
-    if(!CSRF.verify(req.body._csrf)) {
-      return this.get(req, res, false, this.updateErrorMsg, emails);
+    if (!CSRF.verify(req.body._csrf)) {
+      return this.get(req, res, false, [this.updateErrorMsg], emails);
     }
 
     // Remove fully empty entries
     emails = emails.filter(e => !this.emailEntryIsEmpty(e));
 
-    if (emails.some(ot => !ot.adminEmailTypeId || ot.address === '')) {
-      // Retains the posted email data when errors exist
-      return this.get(req, res, false, this.emptyTypeOrAddressErrorMsg, emails);
-    } else {
-
-      // If any address used is not of an email format, return with an error
-      if(emails.some(ot => !validateEmail(ot.address)))
-        return this.get(req, res, false, this.getEmailAddressFormatErrorMsg, emails);
-
-      await req.scope.cradle.api.updateEmails(req.params.slug, emails)
-        .then((value: Email[]) => this.get(req, res, true, '', value))
-        .catch((err: any) => this.get(req, res, false, this.updateErrorMsg, emails));
+    const errorMsg = this.getErrorMessages(emails);
+    if (errorMsg.length > 0) {
+      return this.get(req, res, false, errorMsg, emails);
     }
+
+    await req.scope.cradle.api.updateEmails(req.params.slug, emails)
+      .then((value: Email[]) => this.get(req, res, true, [], value))
+      .catch((err: any) => this.get(req, res, false, [this.updateErrorMsg], emails));
   }
 
   private static getEmailTypesForSelect(standardTypes: EmailType[]): SelectItem[] {
@@ -91,5 +93,27 @@ export class EmailsController {
 
   private emailEntryIsEmpty(email: Email): boolean {
     return (!email.adminEmailTypeId && !email.address?.trim() && !email.explanation?.trim() && !email.explanationCy?.trim());
+  }
+
+  private emailsDuplicated(emails: Email[], index1: number, index2: number): boolean {
+    return emails[index1].address && emails[index1].address === emails[index2].address;
+  }
+
+  private getErrorMessages(emails: Email[]): string[] {
+    const errorMsg: string[] = [];
+    if (emails.some(ot => !ot.adminEmailTypeId || ot.address === '')) {
+      // Retains the posted email data when errors exist
+      errorMsg.push(this.emptyTypeOrAddressErrorMsg);
+    }
+
+    // If any address used is not of an email format, return with an error
+    if (!validateEmailFormat(emails)) {
+      errorMsg.push(this.getEmailAddressFormatErrorMsg);
+    }
+
+    if (!validateDuplication(emails, this.emailsDuplicated)) {
+      errorMsg.push(this.emailDuplicatedErrorMsg);
+    }
+    return errorMsg;
   }
 }

--- a/src/main/app/controller/courts/OpeningTimesController.ts
+++ b/src/main/app/controller/courts/OpeningTimesController.ts
@@ -5,7 +5,7 @@ import {Response} from 'express';
 import {SelectItem} from '../../../types/CourtPageData';
 import {OpeningType} from '../../../types/OpeningType';
 import {CSRF} from '../../../modules/csrf';
-import {validateOpeningTimeDuplicates} from '../../../utils/validation';
+import {validateDuplication} from '../../../utils/validation';
 import {Error} from '../../../types/Error';
 
 @autobind
@@ -73,7 +73,7 @@ export class OpeningTimesController {
       errorMsg.push(this.emptyTypeOrHoursErrorMsg);
     }
 
-    if (!validateOpeningTimeDuplicates(openingTimes)) {
+    if (!validateDuplication(openingTimes, this.openingHoursDuplicated)) {
       errorMsg.push(this.openingTimeDuplicatedErrorMsg);
     }
 
@@ -101,5 +101,9 @@ export class OpeningTimesController {
 
   private openingHoursEntryIsEmpty(openingHours: OpeningTime): boolean {
     return (!openingHours.type_id && !openingHours.hours?.trim());
+  }
+
+  private openingHoursDuplicated(openingHours: OpeningTime[], index1: number, index2: number): boolean {
+    return openingHours[index1].type_id && openingHours[index1].type_id === openingHours[index2].type_id;
   }
 }

--- a/src/main/types/Contact.ts
+++ b/src/main/types/Contact.ts
@@ -1,12 +1,12 @@
 import {SelectItem} from "./CourtPageData";
+import {Element} from "./Element";
 
-export interface Contact {
+export interface Contact extends Element {
   type_id: number;
   number: string;
   fax: boolean;
   explanation: string;
   explanation_cy: string;
-  isNew?: boolean;
 }
 
 export interface ContactPageData {

--- a/src/main/types/CourtType.ts
+++ b/src/main/types/CourtType.ts
@@ -1,6 +1,3 @@
-
-
-
 export interface CourtType {
   id: number,
   name?: string,
@@ -13,7 +10,6 @@ export interface CourtTypePageData {
   items: CourtTypeItem[]
 }
 
-
 export interface CourtTypeItem {
   value: string,
   text: string,
@@ -23,4 +19,3 @@ export interface CourtTypeItem {
   checked: boolean,
   code: number
 }
-

--- a/src/main/types/Element.ts
+++ b/src/main/types/Element.ts
@@ -1,0 +1,4 @@
+export interface Element {
+  isNew?: boolean,
+  isDuplicated?: boolean
+}

--- a/src/main/types/Email.ts
+++ b/src/main/types/Email.ts
@@ -1,16 +1,18 @@
 import {SelectItem} from "./CourtPageData";
+import {Error} from "./Error";
+import {Element} from "./Element";
 
-export interface Email {
+export interface Email extends Element {
   adminEmailTypeId: number,
   explanation: string,
   explanationCy: string,
   address: string,
-  isNew?: boolean
+  isInvalidFormat?: boolean
 }
 
 export interface EmailData {
   emails: Email[],
   emailTypes: SelectItem[],
-  errorMsg: string,
+  errors: Error[],
   updated: boolean
 }

--- a/src/main/types/OpeningTime.ts
+++ b/src/main/types/OpeningTime.ts
@@ -1,11 +1,10 @@
 import {SelectItem} from "./CourtPageData";
 import {Error} from "./Error";
+import {Element} from "./Element";
 
-export interface OpeningTime {
+export interface OpeningTime extends Element {
   type_id: number,
   hours: string,
-  isNew?: boolean,
-  isDuplicated?: boolean
 }
 
 export interface OpeningTimeData {

--- a/src/main/utils/validation.ts
+++ b/src/main/utils/validation.ts
@@ -1,21 +1,30 @@
-import {OpeningTime} from '../types/OpeningTime';
+import {Email} from '../types/Email';
+import {Element} from '../types/Element';
 
 export const isObjectEmpty = (obj: {}): boolean => {
   return Object.keys(obj).length === 0;
 };
 
-export function validateEmail(email: string): boolean {
+export function validateEmailFormat(emails: Email[]): boolean {
   const regexp = new RegExp(/^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/);
-  return regexp.test(email);
+  let hasInvalidFormat = false;
+  for (let i = 0; i < emails.length; i++) {
+    const isValid = regexp.test(emails[i].address);
+    if (!isValid) {
+      emails[i].isInvalidFormat = true;
+      hasInvalidFormat = true;
+    }
+  }
+  return !hasInvalidFormat;
 }
 
-export function validateOpeningTimeDuplicates(openingHours: OpeningTime[]): boolean {
+export function validateDuplication(elements: Element[], predicate: (elements: Element[], b: number, c: number) => boolean): boolean {
   let hasDuplicates = false;
-  for (let i = 0; i < openingHours.length - 1; i++) {
-    for (let j = i + 1; j < openingHours.length; j++) {
-      if (openingHours[i].type_id && openingHours[i].type_id === openingHours[j].type_id) {
-        openingHours[i].isDuplicated = true;
-        openingHours[j].isDuplicated = true;
+  for (let i = 0; i < elements.length - 1; i++) {
+    for (let j = i + 1; j < elements.length; j++) {
+      if (predicate(elements, i, j)) {
+        elements[i].isDuplicated = true;
+        elements[j].isDuplicated = true;
         hasDuplicates = true;
       }
     }

--- a/src/main/views/courts/tabs/emailsContent.njk
+++ b/src/main/views/courts/tabs/emailsContent.njk
@@ -15,14 +15,10 @@
     target='_blank' rel='noopener noreferrer'>email addresses</a>"})
 }}
 
-{% if errorMsg != '' %}
+{% if errors|length %}
   {{ govukErrorSummary({
     titleText: "There is a problem",
-    errorList: [
-      {
-        text: errorMsg
-      }
-    ]
+    errorList: errors
   }) }}
 {% endif %}
 
@@ -38,12 +34,16 @@
 
   {% set descriptionError = false %}
   {% if email.adminEmailTypeId === '' %}
-    {% set descriptionError = { text: 'Type is required' } %}
+    {% set descriptionError = { text: 'Description is required' } %}
   {% endif %}
 
   {% set emailsError = false %}
   {% if email.address === '' %}
-   {% set emailsError = { text: 'Address is required' } %}
+    {% set emailsError = { text: 'Address is required' } %}
+  {% elif email.isDuplicated === true %}
+    {% set emailsError = { text: 'Duplicated address' } %}
+  {% elif email.isInvalidFormat === true %}
+    {% set emailsError = { text: 'Invalid email address format' } %}
   {% endif %}
 
   {% call govukFieldset({}) %}
@@ -58,7 +58,7 @@
     id: "emails-" + loop.index,
     name: "emails[" + loop.index +"][adminEmailTypeId]",
     label: {
-      text: "Type"
+      text: "Description"
     },
     errorMessage: descriptionError,
     items: emailTypes | selectFilter(email.adminEmailTypeId)
@@ -98,13 +98,11 @@
   {% if isNew === false %}
     {{ govukButton({
       text: "Remove",
-      name: "deleteEmails",
+      name: "deleteEmail",
       type: "button",
       classes: "govuk-button--secondary deleteEmail"
     }) }}
-  {% endif %}
-
-  {% if isNew === true %}
+  {% else %}
     {{ govukButton({
       text: "Clear",
       name: "clearEmail",
@@ -117,7 +115,7 @@
 
   {% endcall %}
 
-  {% endfor %}
+{% endfor %}
 
 
 {% call govukFieldset({

--- a/src/test/functional/features/email-addresses.feature
+++ b/src/test/functional/features/email-addresses.feature
@@ -11,34 +11,45 @@ Feature: Email-addresses
     Then I am redirected to the Edit Court page for the chosen court
     When I click the Emails tab
     Then I can view the existing emails
+#
+#  Scenario: Add new Email Addresses
+#    # Clear out potential left-over emails from the previous run before adding new ones
+#    When I remove all existing email entries and save
+#    Then a green update message showing email updated is displayed
+#    When I add Description from the dropdown at index 6 and Address "abs@gmail.com" and Explanation "County Court" and Welsh Explanation "Llys sirol"
+#    Then I click on Add new Email
+#    And I add Description from the dropdown at index 8 and Address "functional.test1@testing.com" and Explanation "Testing - English" and Welsh Explanation "Testing - Welsh"
+#    And I click save button
+#    Then a green update message showing email updated is displayed
+#    And the second last email address is displayed with description at index 6 Address "abs@gmail.com" Explanation "County Court" and Welsh Explanation "Llys sirol"
+#    And the last email address is displayed with description at index 8 Address "functional.test1@testing.com" Explanation "Testing - English" and Welsh Explanation "Testing - Welsh"
+#
+#  Scenario: Incomplete email type and address
+#    When I leave adminId blank
+#    And I add address "incomplete@test.com"
+#    And I click save button
+#    Then A red error message display
+#
+#  Scenario: Remove emails
+#    When I click the remove button below a email section
+#    And I click save button
+#    Then a green update message showing email updated is displayed
+#    When I click the remove button below a email section
+#    And I click save button
+#    Then a green update message showing email updated is displayed
+#
+#  Scenario: Email format validation
+#    When I add Description from the dropdown 6 and wrong Email-Address "abcef"
+#    And I click save button
+#    Then An error message is displayed with the text "Enter an email address in the correct format, like name@example.com"
 
-  Scenario: Add new Email Addresses
-    # Clear out potential left-over emails from the previous run before adding new ones
-    When I remove all existing email entries and save
-    Then a green update message showing email updated is displayed
-    When I add Description from the dropdown at index 6 and Address "abs@gmail.com" and Explanation "County Court" and Welsh Explanation "Llys sirol"
-    Then I click on Add new Email
-    And I add Description from the dropdown at index 8 and Address "functional.test1@testing.com" and Explanation "Testing - English" and Welsh Explanation "Testing - Welsh"
-    And I click save button
-    Then a green update message showing email updated is displayed
-    And the second last email address is displayed with description at index 6 Address "abs@gmail.com" Explanation "County Court" and Welsh Explanation "Llys sirol"
-    And the last email address is displayed with description at index 8 Address "functional.test1@testing.com" Explanation "Testing - English" and Welsh Explanation "Testing - Welsh"
+  Scenario: Prevent duplicated entries being added
+    When I select email description "Admin"
+    And I enter email address "test@gmail.com"
+    And I click on add another button
+    And I click on any description "Admin"
+    And I enter the same email address "test@gmail.com"
+    And I click Save button
+    Then An error is displayed for email address with summary "All email addresses must be unique." and description field message "Duplicated address"
 
-  Scenario: Incomplete email type and address
-    When I leave adminId blank
-    And I add address "incomplete@test.com"
-    And I click save button
-    Then A red error message display
 
-  Scenario: Remove emails
-    When I click the remove button below a email section
-    And I click save button
-    Then a green update message showing email updated is displayed
-    When I click the remove button below a email section
-    And I click save button
-    Then a green update message showing email updated is displayed
-
-  Scenario: Email format validation
-    When I add Description from the dropdown 6 and wrong Email-Address "abcef"
-    And I click save button
-    Then An error message is displayed with the text "Enter an email address in the correct format, like name@example.com"

--- a/src/test/functional/features/email-addresses.feature
+++ b/src/test/functional/features/email-addresses.feature
@@ -11,43 +11,44 @@ Feature: Email-addresses
     Then I am redirected to the Edit Court page for the chosen court
     When I click the Emails tab
     Then I can view the existing emails
-#
-#  Scenario: Add new Email Addresses
-#    # Clear out potential left-over emails from the previous run before adding new ones
-#    When I remove all existing email entries and save
-#    Then a green update message showing email updated is displayed
-#    When I add Description from the dropdown at index 6 and Address "abs@gmail.com" and Explanation "County Court" and Welsh Explanation "Llys sirol"
-#    Then I click on Add new Email
-#    And I add Description from the dropdown at index 8 and Address "functional.test1@testing.com" and Explanation "Testing - English" and Welsh Explanation "Testing - Welsh"
-#    And I click save button
-#    Then a green update message showing email updated is displayed
-#    And the second last email address is displayed with description at index 6 Address "abs@gmail.com" Explanation "County Court" and Welsh Explanation "Llys sirol"
-#    And the last email address is displayed with description at index 8 Address "functional.test1@testing.com" Explanation "Testing - English" and Welsh Explanation "Testing - Welsh"
-#
-#  Scenario: Incomplete email type and address
-#    When I leave adminId blank
-#    And I add address "incomplete@test.com"
-#    And I click save button
-#    Then A red error message display
-#
-#  Scenario: Remove emails
-#    When I click the remove button below a email section
-#    And I click save button
-#    Then a green update message showing email updated is displayed
-#    When I click the remove button below a email section
-#    And I click save button
-#    Then a green update message showing email updated is displayed
-#
-#  Scenario: Email format validation
-#    When I add Description from the dropdown 6 and wrong Email-Address "abcef"
-#    And I click save button
-#    Then An error message is displayed with the text "Enter an email address in the correct format, like name@example.com"
+
+  Scenario: Add new Email Addresses
+    # Clear out potential left-over emails from the previous run before adding new ones
+    When I remove all existing email entries and save
+    Then a green update message showing email updated is displayed
+    When I add Description from the dropdown at index 6 and Address "abs@gmail.com" and Explanation "County Court" and Welsh Explanation "Llys sirol"
+    Then I click on Add new Email
+    And I add Description from the dropdown at index 8 and Address "functional.test1@testing.com" and Explanation "Testing - English" and Welsh Explanation "Testing - Welsh"
+    And I click save button
+    Then a green update message showing email updated is displayed
+    And the second last email address is displayed with description at index 6 Address "abs@gmail.com" Explanation "County Court" and Welsh Explanation "Llys sirol"
+    And the last email address is displayed with description at index 8 Address "functional.test1@testing.com" Explanation "Testing - English" and Welsh Explanation "Testing - Welsh"
+
+  Scenario: Incomplete email type and address
+    When I leave adminId blank
+    And I add address "incomplete@test.com"
+    And I click save button
+    Then A red error message display
+
+  Scenario: Remove emails
+    When I click the remove button below a email section
+    And I click save button
+    Then a green update message showing email updated is displayed
+    When I click the remove button below a email section
+    And I click save button
+    Then a green update message showing email updated is displayed
+
+  Scenario: Email format validation
+    When I add Description from the dropdown 6 and wrong Email-Address "abcef"
+    And I click save button
+    Then An error message is displayed with the text "Enter an email address in the correct format, like name@example.com"
 
   Scenario: Prevent duplicated entries being added
-    When I select email description "Admin"
+    When I remove all existing email entries and save
+    When I add Description from the dropdown 6
     And I enter email address "test@gmail.com"
     And I click on add another button
-    And I click on any description "Admin"
+    And I click on any description 6
     And I enter the same email address "test@gmail.com"
     And I click Save button
     Then An error is displayed for email address with summary "All email addresses must be unique." and description field message "Duplicated address"

--- a/src/test/functional/features/email-addresses.feature
+++ b/src/test/functional/features/email-addresses.feature
@@ -41,7 +41,7 @@ Feature: Email-addresses
   Scenario: Email format validation
     When I add Description from the dropdown 6 and wrong Email-Address "abcef"
     And I click save button
-    Then An error is displayed for email address with summary "Enter an email address in the correct format, like name@example.com" and description field message "Invalid email address format"
+    Then An error is displayed for email address with summary "Enter an email address in the correct format, like name@example.com" and address field message "Invalid email address format"
 
 
   Scenario: Prevent duplicated entries being added
@@ -52,6 +52,6 @@ Feature: Email-addresses
     And I click on any description 6
     And I enter the same email address "test@gmail.com"
     And I click Save button
-    Then An error is displayed for email address with summary "All email addresses must be unique." and description field message "Duplicated address"
+    Then An error is displayed for email address with summary "All email addresses must be unique." and address field message "Duplicated address"
 
 

--- a/src/test/functional/features/email-addresses.feature
+++ b/src/test/functional/features/email-addresses.feature
@@ -41,7 +41,8 @@ Feature: Email-addresses
   Scenario: Email format validation
     When I add Description from the dropdown 6 and wrong Email-Address "abcef"
     And I click save button
-    Then An error message is displayed with the text "Enter an email address in the correct format, like name@example.com"
+    Then An error is displayed for email address with summary "Enter an email address in the correct format, like name@example.com" and description field message "Invalid email address format"
+
 
   Scenario: Prevent duplicated entries being added
     When I remove all existing email entries and save

--- a/src/test/functional/features/email-addresses.feature
+++ b/src/test/functional/features/email-addresses.feature
@@ -13,6 +13,9 @@ Feature: Email-addresses
     Then I can view the existing emails
 
   Scenario: Add new Email Addresses
+    # Clear out potential left-over emails from the previous run before adding new ones
+    When I remove all existing email entries and save
+    Then a green update message showing email updated is displayed
     When I add Description from the dropdown at index 6 and Address "abs@gmail.com" and Explanation "County Court" and Welsh Explanation "Llys sirol"
     Then I click on Add new Email
     And I add Description from the dropdown at index 8 and Address "functional.test1@testing.com" and Explanation "Testing - English" and Welsh Explanation "Testing - Welsh"
@@ -35,13 +38,7 @@ Feature: Email-addresses
     And I click save button
     Then a green update message showing email updated is displayed
 
-  Scenario Outline: Email validation
-    When I add Description from the dropdown <descriptionIndex> and wrong Email-Address "<address>"
+  Scenario: Email format validation
+    When I add Description from the dropdown 6 and wrong Email-Address "abcef"
     And I click save button
-    Then An error message is displayed with the text "<validation>"
-
-    Examples:
-      | descriptionIndex | address          | validation                                                          |
-      | 6                | abcabc@gmailcom. | Enter an email address in the correct format, like name@example.com |
-      | 6                | abcefg!gmail.com | Enter an email address in the correct format, like name@example.com |
-      | 6                | abcef            | Enter an email address in the correct format, like name@example.com |
+    Then An error message is displayed with the text "Enter an email address in the correct format, like name@example.com"

--- a/src/test/functional/steps/email-addresses.ts
+++ b/src/test/functional/steps/email-addresses.ts
@@ -122,15 +122,6 @@ When('I add Description from the dropdown {int} and wrong Email-Address {string}
     await I.setElementValueAtIndex(addressInputSelector, entryFormIdx, email, 'input');
   });
 
-Then('An error message is displayed with the text {string}', async (msg: string) => {
-  expect(await I.checkElement('#error-summary-title')).equal(true);
-  expect(await I.checkElement('#emailsContent > div > div > ul > li')).equal(true);
-  expect(
-    await I.getElementText(                                                // Get Text for the element below
-      await I.getElement('#emailsContent > div > div > ul > li'))) // Get the element for the error
-    .equal(msg);
-});
-
 
 let entryFormInedx = 0;
 

--- a/src/test/functional/steps/email-addresses.ts
+++ b/src/test/functional/steps/email-addresses.ts
@@ -130,3 +130,68 @@ Then('An error message is displayed with the text {string}', async (msg: string)
       await I.getElement('#emailsContent > div > div > ul > li'))) // Get the element for the error
     .equal(msg);
 });
+
+
+
+let entryFormIdx = 0;
+const descriptionSelector = '#emailsTab select[name$="[adminEmailTypeId]]"]';
+const addressSelector = '#emailsTab input[name$="[address]"]';
+
+When('I select email description {string}', async (description: string)=> {
+  await FunctionalTestHelpers.clearFieldsetsAndSave('#emailsTab', 'deleteEmail', 'saveEmail');
+  const numFieldsets = await I.countElement('#emailsTab fieldset');
+
+  if(numFieldsets>0)
+  {
+    entryFormIdx = numFieldsets - 2;
+  }
+  await I.setElementValueAtIndex(descriptionSelector, entryFormIdx, description, 'select');
+});
+
+When('I enter email address {string}', async (address: string)=>{
+
+  await I.setElementValueAtIndex(addressSelector, entryFormIdx, 'address', 'input');
+});
+
+When('I click on add another button', async () =>{
+  await FunctionalTestHelpers.clickButton('#emailsTab', 'addEmail');
+
+});
+
+When('I click on any description {string}', async (description: string) => {
+
+  await I.setElementValueAtIndex(descriptionSelector, entryFormIdx, description, 'select');
+});
+
+When('I enter the same email address {string}', async (address: string) =>{
+
+  await I.setElementValueAtIndex(addressSelector, entryFormIdx, 'address', 'input');
+});
+
+When('I click Save button', async () => {
+  await FunctionalTestHelpers.clickButton('#emailsTab', 'saveEmail');
+});
+
+Then('An error is displayed for email address with summary {string} and description field message {string}', async (summaryErrMsg: string, fieldErrMsg: string) => {
+  const errorTitle = 'There is a problem';
+  let selector = '#error-summary-title';
+  expect(await I.checkElement(selector)).equal(true);
+  const errorTitleElement = await I.getElement(selector);
+  expect(await I.getElementText(errorTitleElement)).equal(errorTitle);
+
+  selector = '#emailContent > div > div > ul > li';
+  expect(await I.checkElement(selector)).equal(true);
+  const errorListElement = await I.getElement(selector);
+  expect(await I.getElementText(errorListElement)).equal(summaryErrMsg);
+
+  const numFieldsets = await I.countElement('#emailTab fieldset');
+  const fieldsetErrorIndex = numFieldsets - 1;  // The last field set is the hidden template fieldset
+  selector = '#email-' + fieldsetErrorIndex + '-error';
+  expect(await I.checkElement(selector)).equal(true);
+  const descriptionErrorElement = await I.getElement(selector);
+  expect(await I.getElementText(descriptionErrorElement)).contains(fieldErrMsg);
+
+  expect(await I.checkElement('#address-' + fieldsetErrorIndex + '-error')).equal(false);
+});
+
+

--- a/src/test/functional/steps/email-addresses.ts
+++ b/src/test/functional/steps/email-addresses.ts
@@ -2,7 +2,7 @@ import {Then, When} from 'cucumber';
 import {expect} from 'chai';
 
 import * as I from '../utlis/puppeteer.util';
-import {FunctionalTestHelpers} from "../utlis/helpers";
+import {FunctionalTestHelpers} from '../utlis/helpers';
 
 When('I click the Emails tab', async () => {
   const selector = '#tab_emails';

--- a/src/test/functional/steps/email-addresses.ts
+++ b/src/test/functional/steps/email-addresses.ts
@@ -158,7 +158,7 @@ When('I click Save button', async () => {
   await FunctionalTestHelpers.clickButton('#emailsTab', 'saveEmail');
 });
 
-Then('An error is displayed for email address with summary {string} and description field message {string}', async (summaryErrMsg: string, fieldErrMsg: string) => {
+Then('An error is displayed for email address with summary {string} and address field message {string}', async (summaryErrMsg: string, fieldErrMsg: string) => {
   const errorTitle = 'There is a problem';
   let selector = '#error-summary-title';
   expect(await I.checkElement(selector)).equal(true);

--- a/src/test/functional/steps/email-addresses.ts
+++ b/src/test/functional/steps/email-addresses.ts
@@ -132,40 +132,35 @@ Then('An error message is displayed with the text {string}', async (msg: string)
 });
 
 
+let entryFormInedx = 0;
 
-let entryFormIdx = 0;
-const descriptionSelector = '#emailsTab select[name$="[adminEmailTypeId]]"]';
-const addressSelector = '#emailsTab input[name$="[address]"]';
-
-When('I select email description {string}', async (description: string)=> {
-  await FunctionalTestHelpers.clearFieldsetsAndSave('#emailsTab', 'deleteEmail', 'saveEmail');
+When('I add Description from the dropdown {int}', async (description: number) => {
   const numFieldsets = await I.countElement('#emailsTab fieldset');
-
-  if(numFieldsets>0)
-  {
-    entryFormIdx = numFieldsets - 2;
+  const descriptionSelector = '#emailsTab select[name$="[adminEmailTypeId]"]';
+  if (numFieldsets > 0) {
+    entryFormInedx = numFieldsets - 2;
   }
-  await I.setElementValueAtIndex(descriptionSelector, entryFormIdx, description, 'select');
+  await I.setElementValueAtIndex(descriptionSelector, entryFormInedx, description, 'select');
 });
 
-When('I enter email address {string}', async (address: string)=>{
-
-  await I.setElementValueAtIndex(addressSelector, entryFormIdx, 'address', 'input');
+When('I enter email address {string}', async (address: string) => {
+  const emailAddressSelector = '#emailsTab input[name$="[address]"]';
+  await I.setElementValueAtIndex(emailAddressSelector, entryFormInedx, address, 'input');
 });
 
-When('I click on add another button', async () =>{
+When('I click on add another button', async () => {
   await FunctionalTestHelpers.clickButton('#emailsTab', 'addEmail');
 
 });
 
-When('I click on any description {string}', async (description: string) => {
-
-  await I.setElementValueAtIndex(descriptionSelector, entryFormIdx, description, 'select');
+When('I click on any description {int}', async (description: number) => {
+  const descriptionSelector = '#emailsTab select[name$="[adminEmailTypeId]"]';
+  await I.setElementValueAtIndex(descriptionSelector, entryFormInedx + 1, description, 'select');
 });
 
-When('I enter the same email address {string}', async (address: string) =>{
-
-  await I.setElementValueAtIndex(addressSelector, entryFormIdx, 'address', 'input');
+When('I enter the same email address {string}', async (address: string) => {
+  const emailAddressSelector = '#emailsTab input[name$="[address]"]';
+  await I.setElementValueAtIndex(emailAddressSelector, entryFormInedx + 1, address, 'input');
 });
 
 When('I click Save button', async () => {
@@ -179,19 +174,21 @@ Then('An error is displayed for email address with summary {string} and descript
   const errorTitleElement = await I.getElement(selector);
   expect(await I.getElementText(errorTitleElement)).equal(errorTitle);
 
-  selector = '#emailContent > div > div > ul > li';
+  selector = '#emailsContent > div > div > ul > li';
   expect(await I.checkElement(selector)).equal(true);
-  const errorListElement = await I.getElement(selector);
-  expect(await I.getElementText(errorListElement)).equal(summaryErrMsg);
 
-  const numFieldsets = await I.countElement('#emailTab fieldset');
+  const errorListElement = await I.getElement(selector);
+
+  expect(await I.getElementText(errorListElement)).equal(summaryErrMsg);
+  const numFieldsets = await I.countElement('#emailsTab fieldset');
+
   const fieldsetErrorIndex = numFieldsets - 1;  // The last field set is the hidden template fieldset
-  selector = '#email-' + fieldsetErrorIndex + '-error';
+
+  selector = '#address-' + fieldsetErrorIndex + '-error';
   expect(await I.checkElement(selector)).equal(true);
   const descriptionErrorElement = await I.getElement(selector);
   expect(await I.getElementText(descriptionErrorElement)).contains(fieldErrMsg);
 
-  expect(await I.checkElement('#address-' + fieldsetErrorIndex + '-error')).equal(false);
 });
 
 

--- a/src/test/functional/steps/email-addresses.ts
+++ b/src/test/functional/steps/email-addresses.ts
@@ -2,6 +2,7 @@ import {Then, When} from 'cucumber';
 import {expect} from 'chai';
 
 import * as I from '../utlis/puppeteer.util';
+import {FunctionalTestHelpers} from "../utlis/helpers";
 
 When('I click the Emails tab', async () => {
   const selector = '#tab_emails';
@@ -15,11 +16,12 @@ Then('I can view the existing emails', async () => {
   expect(elementExist).equal(true);
 });
 
+When('I remove all existing email entries and save', async () => {
+  await FunctionalTestHelpers.clearFieldsetsAndSave('#emailsTab', 'deleteEmail', 'saveEmail');
+});
+
 When('I click on Add new Email', async () => {
-  const selector = 'button[name=\'addEmail\']';
-  const elementExist = await I.checkElement(selector);
-  expect(elementExist).equal(true);
-  await I.click(selector);
+  await FunctionalTestHelpers.clickButton('#emailsTab', 'addEmail');
 });
 
 When('I add Description from the dropdown at index {int} and Address {string} and Explanation {string} and Welsh Explanation {string}',
@@ -44,10 +46,7 @@ When('I add Description from the dropdown at index {int} and Address {string} an
   });
 
 When('I click save button', async () => {
-  const selector = 'button[name=\'saveEmail\']';
-  const elementExist = await I.checkElement(selector);
-  expect(elementExist).equal(true);
-  await I.click(selector);
+  await FunctionalTestHelpers.clickButton('#emailsTab', 'saveEmail');
 });
 
 Then('a green update message showing email updated is displayed', async () => {
@@ -106,12 +105,7 @@ Then('A red error message display', async () => {
 
 When('I click the remove button below a email section', async () => {
   const numEmailAdd = await I.countElement('#emailsTab fieldset');
-
-  const selector = 'button[name=\'deleteEmails\']';
-  const elementExist = await I.checkElement(selector);
-  expect(elementExist).equal(true);
-  await I.click(selector);
-
+  await FunctionalTestHelpers.clickButton('#emailsTab', 'deleteEmail');
   const updatedEmailAdd = await I.countElement('#emailsTab fieldset');
   expect(numEmailAdd - updatedEmailAdd).equal(1);
 });

--- a/src/test/unit/app/controller/courts/EmailsController.ts
+++ b/src/test/unit/app/controller/courts/EmailsController.ts
@@ -13,13 +13,16 @@ describe('EmailsController', () => {
     updateEmails: () => Promise<Email[]>,
     getEmailTypes: () => Promise<EmailType[]> };
 
+  const testEmail1 = 'abc@test.com';
+  const testEmail2 = 'abc@test2.com';
+
   const getEmails: () => Email[] = () => [
     {
-      address: 'abc@test.com', explanation: 'explanation ',
+      address: testEmail1, explanation: 'explanation ',
       explanationCy: 'explanation cy', adminEmailTypeId: 8, isNew: false
     },
     {
-      address: 'abc@test2.com', explanation: 'explanation 2',
+      address: testEmail2, explanation: 'explanation 2',
       explanationCy: 'explanation cy 2', adminEmailTypeId: 2, isNew: false
     }
   ];
@@ -87,7 +90,7 @@ describe('EmailsController', () => {
       emails: emailsWithEmptyEntry,
       emailTypes: expectedSelectItems,
       updated: false,
-      errorMsg: ''
+      errors: []
     };
     expect(res.render).toBeCalledWith('courts/tabs/emailsContent', expectedResults);
   });
@@ -110,7 +113,30 @@ describe('EmailsController', () => {
     expect(mockApi.updateEmails).toBeCalledWith(slug, getEmails());
   });
 
-  test('Should not post emails if type or address field(s) are empty', async() => {
+  test('Should not post emails if description or address field(s) are empty', async() => {
+    const slug = 'another-county-court';
+    const res = mockResponse();
+    const req = mockRequest();
+    const postedEmails: Email[] = [
+      { adminEmailTypeId: 1, address: null, explanation: null, explanationCy: null},
+      { adminEmailTypeId: null, address: 'an address', explanation: null, explanationCy: null }
+    ];
+
+    req.body = {
+      'emails': postedEmails,
+      '_csrf': CSRF.create()
+    };
+    req.params = { slug: slug };
+    req.scope.cradle.api = mockApi;
+    req.scope.cradle.api.updateEmails = jest.fn().mockReturnValue(res);
+
+    await controller.put(req, res);
+
+    // Should not call API if emails data is incomplete
+    expect(mockApi.updateEmails).not.toBeCalled();
+  });
+
+  test('Should not post emails if descriptions are duplicated', async() => {
     const slug = 'another-county-court';
     const res = mockResponse();
     const req = mockRequest();
@@ -153,34 +179,48 @@ describe('EmailsController', () => {
       emails: emailsInvalidSyntax,
       emailTypes: expectedSelectItems,
       updated: false,
-      errorMsg: 'A problem occurred when saving the emails.'
+      errors: [{text: controller.updateErrorMsg}]
     };
     expect(mockApi.updateEmails).not.toBeCalled();
     expect(res.render).toBeCalledWith('courts/tabs/emailsContent', expectedResults);
   });
 
-  test('Should handle email address error invalid syntax when getting email data from API', async () => {
-    const req = mockRequest();
-    req.params = {
-      slug: 'plymouth-combined-court'
-    };
-    req.body = {
-      'emails': emailsInvalidSyntax,
-      '_csrf': CSRF.create()
-    };
-    req.scope.cradle.api = mockApi;
-    req.scope.cradle.api.getEmails = jest.fn().mockRejectedValue(new Error('Mock API Error'));
-    const res = mockResponse();
+  const parameters = [
+    { email: 'abcabc@gmailcom.' },
+    { email: 'abcefg!gmail.com' },
+    { email: 'abc' }
+  ];
 
-    await controller.put(req, res);
+  parameters.forEach((parameter) => {
+    it('Should handle invalid email address format \'' + parameter.email + '\' when getting email data from API', async () => {
+      const postedEmails = [
+        {
+          address: parameter.email, explanation: 'explanation ',
+          explanationCy: 'explanation cy', adminEmailTypeId: 8, isNew: true
+        }
+      ];
+      const req = mockRequest();
+      req.params = {
+        slug: 'plymouth-combined-court'
+      };
+      req.body = {
+        'emails': postedEmails,
+        '_csrf': CSRF.create()
+      };
+      req.scope.cradle.api = mockApi;
+      req.scope.cradle.api.getEmails = jest.fn().mockRejectedValue(new Error('Mock API Error'));
+      const res = mockResponse();
 
-    const expectedResults: EmailData = {
-      emails: emailsInvalidSyntax,
-      emailTypes: expectedSelectItems,
-      updated: false,
-      errorMsg: controller.getEmailAddressFormatErrorMsg
-    };
-    expect(res.render).toBeCalledWith('courts/tabs/emailsContent', expectedResults);
+      await controller.put(req, res);
+
+      const expectedResults: EmailData = {
+        emails: postedEmails,
+        emailTypes: expectedSelectItems,
+        updated: false,
+        errors: [{text: controller.getEmailAddressFormatErrorMsg}]
+      };
+      expect(res.render).toBeCalledWith('courts/tabs/emailsContent', expectedResults);
+    });
   });
 
   test('Should handle address blank error when getting email data from API', async () => {
@@ -198,7 +238,7 @@ describe('EmailsController', () => {
       emails: null,
       emailTypes: expectedSelectItems,
       updated: false,
-      errorMsg: controller.getEmailsErrorMsg
+      errors: [{text: controller.getEmailsErrorMsg}]
     };
     expect(res.render).toBeCalledWith('courts/tabs/emailsContent', expectedResults);
   });
@@ -218,7 +258,61 @@ describe('EmailsController', () => {
       emails: emailsWithEmptyEntry,
       emailTypes: [],
       updated: false,
-      errorMsg: controller.getEmailTypesErrorMsg
+      errors: [{text: controller.getEmailTypesErrorMsg}]
+    };
+    expect(res.render).toBeCalledWith('courts/tabs/emailsContent', expectedResults);
+  });
+
+  test('Should handle error with duplicated addresses when updating emails', async () => {
+    const req = mockRequest();
+    const postedEmails: Email[] = getEmails().concat({ adminEmailTypeId: 5, address: testEmail1, explanation: null, explanationCy: null, isNew: true });
+    req.params = { slug: 'plymouth-combined-court' };
+    req.body = {
+      'emails': postedEmails,
+      '_csrf': CSRF.create()
+    };
+    req.scope.cradle.api = mockApi;
+    req.scope.cradle.api.updateEmails = jest.fn().mockRejectedValue(new Error('Mock API Error'));
+    const res = mockResponse();
+
+    await controller.put(req, res);
+
+    const expectedResults: EmailData = {
+      'emails': postedEmails,
+      emailTypes: expectedSelectItems,
+      updated: false,
+      errors: [{text: controller.emailDuplicatedErrorMsg}]
+    };
+    expect(res.render).toBeCalledWith('courts/tabs/emailsContent', expectedResults);
+  });
+
+  test('Should handle multiple errors when updating emails', async () => {
+    const req = mockRequest();
+    const postedEmails: Email[] = getEmails()
+      .concat({ adminEmailTypeId: 4, address: 'abc', explanation: null, explanationCy: null, isNew: true })
+      .concat({ adminEmailTypeId: 5, address: testEmail1, explanation: null, explanationCy: null, isNew: true })
+      .concat({ adminEmailTypeId: 6, address: '', explanation: null, explanationCy: null, isNew: true });
+
+    req.params = { slug: 'plymouth-combined-court' };
+    req.body = {
+      'emails': postedEmails,
+      '_csrf': CSRF.create()
+    };
+    req.scope.cradle.api = mockApi;
+    req.scope.cradle.api.updateEmails = jest.fn().mockRejectedValue(new Error('Mock API Error'));
+    const res = mockResponse();
+
+    await controller.put(req, res);
+
+    const expectedResults: EmailData = {
+      'emails': postedEmails,
+      emailTypes: expectedSelectItems,
+      updated: false,
+      errors: [
+        {text: controller.emptyTypeOrAddressErrorMsg},
+        {text: controller.getEmailAddressFormatErrorMsg},
+        {text: controller.emailDuplicatedErrorMsg}
+      ]
     };
     expect(res.render).toBeCalledWith('courts/tabs/emailsContent', expectedResults);
   });


### PR DESCRIPTION
### JIRA link ###

https://tools.hmcts.net/jira/browse/FACT-541
https://tools.hmcts.net/jira/browse/FACT-589

### Change description ###

Display error when user input duplicated email addresses.
Allow multiple errors to be shown in email error summary.
Fix issue where e-mail format error not highlighted in the address textbox.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
