### PR TITLE
making common flag checbox disabled for all service centres

### DIFF
--- a/src/main/views/courts/tabs/generalContent.njk
+++ b/src/main/views/courts/tabs/generalContent.njk
@@ -70,7 +70,6 @@
       }
     ]
   }) }}
-{% set disableCommonPlatform = generalInfo.service_centre == true %}
 {{ govukCheckboxes({
     name: "common_platform",
     items: [
@@ -78,7 +77,7 @@
         value: true,
         text: "Common Platform",
         checked: generalInfo.common_platform,
-        disabled: disableCommonPlatform
+        disabled: generalInfo.service_centre
       }
     ]
   }) }}


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/FACT-1007


making commmon flag checbox disabled for all service centres



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
