### PR TITLE
adding disabled save buttons on all tabs  when service is down

### DIFF
--- a/src/main/app/controller/courts/AdditionalLinksController.ts
+++ b/src/main/app/controller/courts/AdditionalLinksController.ts
@@ -24,12 +24,13 @@ export class AdditionalLinksController {
     links: AdditionalLink[] = null): Promise<void> {
 
     const slug: string = req.params.slug as string;
+    let fatalError = false;
 
     if (!links) {
       // Retrieve additional links from API and set the isNew property to false on all existing link entries.
       await req.scope.cradle.api.getCourtAdditionalLinks(slug)
         .then((value: AdditionalLink[]) => links = value.map(e => { e.isNew = false; return e; }))
-        .catch(() => errorMessages.push(this.getAdditionalLinksErrorMsg));
+        .catch(() => {errorMessages.push(this.getAdditionalLinksErrorMsg); fatalError = true;});
     }
 
     if (!links?.some(e => e.isNew === true)) {
@@ -44,7 +45,8 @@ export class AdditionalLinksController {
     const pageData: AdditionalLinkData = {
       links: links,
       errors: errors,
-      updated: updated
+      updated: updated,
+      fatalError: fatalError,
     };
     res.render('courts/tabs/additionalLinksContent', pageData);
   }

--- a/src/main/app/controller/courts/ApplicationProgressionController.ts
+++ b/src/main/app/controller/courts/ApplicationProgressionController.ts
@@ -28,13 +28,14 @@ export class ApplicationProgressionController {
     applicationProgressions: ApplicationProgression[] = null): Promise<void> {
 
     const slug: string = req.params.slug as string;
+    let fatalError = false;
 
     if (!applicationProgressions) {
       // Get application updates from API and set the isNew property to false on all application update entries.
       await req.scope.cradle.api.getApplicationUpdates(slug)
         .then((value: ApplicationProgression[]) => applicationProgressions = value.map(e => {
           e.isNew = false; return e; }))
-        .catch(() => errorMsg.push(this.getApplicationUpdatesErrorMsg));
+        .catch(() => {errorMsg.push(this.getApplicationUpdatesErrorMsg); fatalError = true;});
     }
 
     let generalInfo: boolean = null;
@@ -56,7 +57,8 @@ export class ApplicationProgressionController {
       'application_progression': applicationProgressions,
       isEnabled: generalInfo,
       errors: errors,
-      updated: updated
+      updated: updated,
+      fatalError: fatalError
     };
 
     res.render('courts/tabs/applicationProgressionContent', pageData);

--- a/src/main/app/controller/courts/CasesHeardController.ts
+++ b/src/main/app/controller/courts/CasesHeardController.ts
@@ -42,11 +42,13 @@ export class CasesHeardController {
     courtAreasOfLaw: AreaOfLaw[] = null) {
 
     const slug: string = req.params.slug as string;
+    let fatalError = false;
     if (!allAreasOfLaw) {
       await req.scope.cradle.api.getAllAreasOfLaw()
         .then((value: AreaOfLaw[]) => allAreasOfLaw = value)
         .catch(() => {
           errorMsg.push(this.getAreasOfLawErrorMsg);
+          fatalError = true;
         });
     }
 
@@ -55,6 +57,7 @@ export class CasesHeardController {
         .then((value: AreaOfLaw[]) => courtAreasOfLaw = value)
         .catch(() => {
           errorMsg.push(this.getCourtAreasOfLawErrorMsg);
+          fatalError = true;
         });
     }
 
@@ -68,7 +71,8 @@ export class CasesHeardController {
       courtAreasOfLaw: courtAreasOfLaw,
       slug: slug,
       errorMsg: errors,
-      updated: updated
+      updated: updated,
+      fatalError: fatalError
     };
 
     res.render('courts/tabs/casesHeardContent', pageData);

--- a/src/main/app/controller/courts/ContactsController.ts
+++ b/src/main/app/controller/courts/ContactsController.ts
@@ -22,18 +22,19 @@ export class ContactsController {
     contacts: Contact[] = null): Promise<void> {
 
     const slug: string = req.params.slug as string;
+    let fatalError = false;
 
     if (!contacts) {
       // Get contacts from API and set the isNew property to false on each if API call successful.
       await req.scope.cradle.api.getContacts(slug)
         .then((value: Contact[]) => contacts = value.map(c => { c.isNew = false; return c; }))
-        .catch(() => error += this.getContactsErrorMsg);
+        .catch(() => {error += this.getContactsErrorMsg; fatalError= true; });
     }
 
     let types: ContactType[] = [];
     await req.scope.cradle.api.getContactTypes()
       .then((value: ContactType[]) => types = value)
-      .catch(() => error += this.getContactTypesErrorMsg);
+      .catch(() => {error += this.getContactTypesErrorMsg; fatalError= true;} );
 
     if (!contacts?.some(c => c.isNew === true)) {
       this.addEmptyFormsForNewEntries(contacts);
@@ -43,7 +44,8 @@ export class ContactsController {
       contacts: contacts,
       contactTypes: this.getContactTypesForSelect(types),
       errorMsg: error,
-      updated: updated
+      updated: updated,
+      fatalError: fatalError
     };
 
     res.render('courts/tabs/phoneNumbersContent', pageData);

--- a/src/main/app/controller/courts/CourtFacilitiesController.ts
+++ b/src/main/app/controller/courts/CourtFacilitiesController.ts
@@ -23,18 +23,19 @@ export class CourtFacilitiesController {
     errorMsg: string[] = [],
     courtFacilities: Facility[] = null,
     requiresValidation = true): Promise<void> {
+    let allFacilitiesTypes: FacilityType[] = [];
+    let fatalError = false;
+
     if (!courtFacilities) {
       const slug: string = req.params.slug as string;
       await req.scope.cradle.api.getCourtFacilities(slug)
         .then((value: Facility[]) => courtFacilities = value)
-        .catch(() => errorMsg.push(this.getCourtFacilitiesErrorMsg));
+        .catch(() => {errorMsg.push(this.getCourtFacilitiesErrorMsg); fatalError = true;});
     }
-
-    let allFacilitiesTypes: FacilityType[] = [];
 
     await req.scope.cradle.api.getAllFacilityTypes()
       .then((value: FacilityType[]) => allFacilitiesTypes = value)
-      .catch(() => errorMsg.push(this.getFacilityTypesErrorMsg));
+      .catch(() => {errorMsg.push(this.getFacilityTypesErrorMsg); fatalError = true;});
 
     if (!courtFacilities?.some(ot => ot.isNew === true)) {
       this.addEmptyFormsForNewEntries(courtFacilities);
@@ -50,7 +51,8 @@ export class CourtFacilitiesController {
       updated: updated,
       facilitiesTypes: CourtFacilitiesController.getFacilityTypesForSelect(allFacilitiesTypes),
       courtFacilities: courtFacilities,
-      requiresValidation: requiresValidation
+      requiresValidation: requiresValidation,
+      fatalError: fatalError
     };
 
     res.render('courts/tabs/facilitiesContent', pageData);

--- a/src/main/app/controller/courts/CourtSpoeController.ts
+++ b/src/main/app/controller/courts/CourtSpoeController.ts
@@ -42,11 +42,13 @@ export class CourtSpoeController {
     courtSpoeAreasOfLaw: SpoeAreaOfLaw[] = null) {
 
     const slug: string = req.params.slug as string;
+    let fatalError = false;
     if (!allSpoeAreasOfLaw) {
       await req.scope.cradle.api.getAllSpoeAreasOfLaw()
         .then((value: SpoeAreaOfLaw[]) => allSpoeAreasOfLaw = value)
         .catch(() => {
           errorMsg.push(this.getSpoeAreasOfLawErrorMsg);
+          fatalError = true;
         });
     }
 
@@ -55,6 +57,7 @@ export class CourtSpoeController {
         .then((value: SpoeAreaOfLaw[]) => courtSpoeAreasOfLaw = value)
         .catch(() => {
           errorMsg.push(this.getCourtSpoeAreasOfLawErrorMsg);
+          fatalError = true;
         });
     }
 
@@ -68,7 +71,8 @@ export class CourtSpoeController {
       courtSpoeAreasOfLaw: courtSpoeAreasOfLaw,
       slug: slug,
       errorMsg: errors,
-      updated: updated
+      updated: updated,
+      fatalError: fatalError
     };
 
     res.render('courts/tabs/spoeContent', pageData);

--- a/src/main/app/controller/courts/CourtTypesController.ts
+++ b/src/main/app/controller/courts/CourtTypesController.ts
@@ -32,10 +32,11 @@ export class CourtTypesController {
     error = '',
     courtTypesAndCodes: CourtTypesAndCodes = null ): Promise<void> {
     const slug: string = req.params.slug as string;
+    let fatalError = false;
     if (courtTypesAndCodes == null) {
       await req.scope.cradle.api.getCourtTypesAndCodes(slug)
         .then((value: CourtTypesAndCodes) => courtTypesAndCodes = value)
-        .catch(() => error += this.getCourtTypesAndCodesErrorMsg);
+        .catch(() => {error += this.getCourtTypesAndCodesErrorMsg; fatalError = true;});
     }
     let courtTypes: CourtType[] = [];
 
@@ -46,7 +47,7 @@ export class CourtTypesController {
 
       await req.scope.cradle.api.getCourtTypes(slug)
         .then((value: CourtType[]) => courtTypes = value)
-        .catch(() => error += this.getCourtTypesErrorMsg);
+        .catch(() => {error += this.getCourtTypesErrorMsg; fatalError = true;});
     }
 
 
@@ -56,7 +57,8 @@ export class CourtTypesController {
       updated: updated,
       courtTypes: courtTypesAndCodes && courtTypesAndCodes.types ? this.mapCourtTypeToCourtTypeItem(courtTypes, courtTypesAndCodes.types) : this.mapCourtTypeToCourtTypeItem(courtTypes, []),
       gbs: courtTypesAndCodes ? courtTypesAndCodes.gbsCode : null,
-      dxCodes: courtTypesAndCodes ? courtTypesAndCodes.dxCodes : []
+      dxCodes: courtTypesAndCodes ? courtTypesAndCodes.dxCodes : [],
+      fatalError: fatalError
     };
 
     res.render('courts/tabs/typesContent', pageData);

--- a/src/main/app/controller/courts/EmailsController.ts
+++ b/src/main/app/controller/courts/EmailsController.ts
@@ -26,18 +26,19 @@ export class EmailsController {
     emails: Email[] = null): Promise<void> {
 
     const slug: string = req.params.slug as string;
+    let fatalError = false;
 
     if (!emails) {
       // Get emails from API and set the isNew property to false on all email entries.
       await req.scope.cradle.api.getEmails(slug)
         .then((value: Email[]) => emails = value.map(e => { e.isNew = false; return e; }))
-        .catch(() => errorMsg.push(this.getEmailsErrorMsg));
+        .catch(() => {errorMsg.push(this.getEmailsErrorMsg); fatalError = true;});
     }
 
     let types: EmailType[] = [];
     await req.scope.cradle.api.getEmailTypes()
       .then((value: EmailType[]) => types = value)
-      .catch(() => errorMsg.push(this.getEmailTypesErrorMsg));
+      .catch(() => {errorMsg.push(this.getEmailTypesErrorMsg); fatalError = true;});
 
     if (!emails?.some(e => e.isNew === true)) {
       this.addEmptyFormsForNewEntries(emails);
@@ -52,7 +53,8 @@ export class EmailsController {
       'emails': emails,
       emailTypes: EmailsController.getEmailTypesForSelect(types),
       errors: errors,
-      updated: updated
+      updated: updated,
+      fatalError: fatalError
     };
     res.render('courts/tabs/emailsContent', pageData);
   }

--- a/src/main/app/controller/courts/GeneralInfoController.ts
+++ b/src/main/app/controller/courts/GeneralInfoController.ts
@@ -27,18 +27,20 @@ export class GeneralInfoController {
     generalInfo: CourtGeneralInfo = null): Promise<void> {
 
     const slug: string = req.params.slug as string;
+    let fatalError = false;
 
     if (!generalInfo) {
       await req.scope.cradle.api.getGeneralInfo(slug)
         .then((value: CourtGeneralInfo) => generalInfo = value)
-        .catch(() => error += this.getGeneralInfoErrorMsg);
+        .catch(() => {error += this.getGeneralInfoErrorMsg; fatalError = true});
     }
 
     const pageData: CourtGeneralInfoData = {
       generalInfo: generalInfo,
       errorMsg: error,
       updated: updated,
-      nameFieldError: nameFieldErrorMsg
+      nameFieldError: nameFieldErrorMsg,
+      fatalError: fatalError
     };
 
     res.render('courts/tabs/generalContent', pageData);

--- a/src/main/app/controller/courts/GeneralInfoController.ts
+++ b/src/main/app/controller/courts/GeneralInfoController.ts
@@ -32,7 +32,7 @@ export class GeneralInfoController {
     if (!generalInfo) {
       await req.scope.cradle.api.getGeneralInfo(slug)
         .then((value: CourtGeneralInfo) => generalInfo = value)
-        .catch(() => {error += this.getGeneralInfoErrorMsg; fatalError = true});
+        .catch(() => {error += this.getGeneralInfoErrorMsg; fatalError = true;});
     }
 
     const pageData: CourtGeneralInfoData = {

--- a/src/main/app/controller/courts/LocalAuthoritiesController.ts
+++ b/src/main/app/controller/courts/LocalAuthoritiesController.ts
@@ -30,30 +30,33 @@ export class LocalAuthoritiesController {
     error = '',
     areasOfLaw: AreaOfLaw[] = null): Promise<void> {
     const slug: string = req.params.slug as string;
+    let fatalError = false;
 
     if (!areasOfLaw ) {
       await req.scope.cradle.api.getCourtAreasOfLaw(slug)
         .then((value: AreaOfLaw[]) => areasOfLaw = value)
-        .catch(() => error += this.getCourtAreasOfLawErrorMsg);
+        .catch(() => {error += this.getCourtAreasOfLawErrorMsg; fatalError = true;});
     }
 
     if (areasOfLaw ){
       areasOfLaw = this.checkFamilyAreasOfLaw(areasOfLaw);
       if(!areasOfLaw.length){
         error += this.familyAreaOfLawErrorMsg;
+        fatalError = true ;
       }
     }
 
     let courtTypes: CourtType[] = [];
     await req.scope.cradle.api.getCourtTypesAndCodes(slug)
       .then((value: CourtTypesAndCodes) => courtTypes = value.types)
-      .catch(() => error += this.getCourtTypesErrorMsg);
+      .catch(() => {error += this.getCourtTypesErrorMsg; fatalError = true});
 
     const pageData: LocalAuthoritiesAreaOfLaw = {
       errorMsg: error,
       updated: updated,
       isEnabled: !courtTypes.length ? false :courtTypes.some(c => c.name === 'Family Court'),
       courtAreasOfLaw: this.getAreasOfLawForSelect(areasOfLaw, ''),
+      fatalError: fatalError
     };
 
     res.render('courts/tabs/localAuthoritiesContent', pageData);

--- a/src/main/app/controller/courts/LocalAuthoritiesController.ts
+++ b/src/main/app/controller/courts/LocalAuthoritiesController.ts
@@ -49,7 +49,7 @@ export class LocalAuthoritiesController {
     let courtTypes: CourtType[] = [];
     await req.scope.cradle.api.getCourtTypesAndCodes(slug)
       .then((value: CourtTypesAndCodes) => courtTypes = value.types)
-      .catch(() => {error += this.getCourtTypesErrorMsg; fatalError = true});
+      .catch(() => {error += this.getCourtTypesErrorMsg; fatalError = true;});
 
     const pageData: LocalAuthoritiesAreaOfLaw = {
       errorMsg: error,

--- a/src/main/app/controller/courts/NewCourtController.ts
+++ b/src/main/app/controller/courts/NewCourtController.ts
@@ -31,12 +31,13 @@ export class NewCourtController {
     serviceAreas: ServiceArea[] = [],
     errorMsg: string[] = []): Promise<void> {
 
+    let fatalError = false;
     const allServiceAreas = await req.scope.cradle.api.getAllServiceAreas()
       .catch(() => {
         errorMsg.push(this.getServiceAreasErrorMsg);
+        fatalError = true;
       });
 
-    console.log(allServiceAreas);
 
     res.render('courts/addNewCourt', {
       created: created,
@@ -51,7 +52,8 @@ export class NewCourtController {
       serviceAreas: serviceAreas,
       allServiceAreas: allServiceAreas,
       errorMsg: errorMsg,
-      csrfToken: CSRF.create()
+      csrfToken: CSRF.create(),
+      fatalError: fatalError,
     });
   }
 

--- a/src/main/app/controller/courts/OpeningTimesController.ts
+++ b/src/main/app/controller/courts/OpeningTimesController.ts
@@ -23,20 +23,20 @@ export class OpeningTimesController {
     updated = false,
     errorMsg: string[] = [],
     openingTimes: OpeningTime[] = null): Promise<void> {
-
+    let fatalError = false;
     const slug: string = req.params.slug as string;
 
     if (!openingTimes) {
       // Get opening times from API and set the isNew property to false on each if API call successful.
       await req.scope.cradle.api.getOpeningTimes(slug)
         .then((value: OpeningTime[]) => openingTimes = value.map(ot => { ot.isNew = false; return ot; }))
-        .catch(() => errorMsg.push(this.getOpeningTimesErrorMsg));
+        .catch(() => {errorMsg.push(this.getOpeningTimesErrorMsg); fatalError = true;});
     }
 
     let types: OpeningType[] = [];
     await req.scope.cradle.api.getOpeningTimeTypes()
       .then((value: OpeningType[]) => types = value)
-      .catch(() => errorMsg.push(this.getOpeningTypesErrorMsg));
+      .catch(() => {errorMsg.push(this.getOpeningTypesErrorMsg); fatalError = true;});
 
     if (!openingTimes?.some(ot => ot.isNew === true)) {
       this.addEmptyFormsForNewEntries(openingTimes);
@@ -51,7 +51,8 @@ export class OpeningTimesController {
       'opening_times': openingTimes,
       openingTimeTypes: OpeningTimesController.getOpeningTimeTypesForSelect(types),
       errors: errors,
-      updated: updated
+      updated: updated,
+      fatalError: fatalError
     };
 
     res.render('courts/tabs/openingHoursContent', pageData);

--- a/src/main/types/AdditionalLink.ts
+++ b/src/main/types/AdditionalLink.ts
@@ -10,5 +10,6 @@ export interface AdditionalLink extends Element {
 export interface AdditionalLinkData {
   links: AdditionalLink[],
   errors: Error[],
-  updated: boolean
+  updated: boolean,
+  fatalError: boolean,
 }

--- a/src/main/types/ApplicationProgression.ts
+++ b/src/main/types/ApplicationProgression.ts
@@ -14,5 +14,6 @@ export interface ApplicationProgressionData {
   application_progression: ApplicationProgression[],
   isEnabled : boolean,
   errors: Error[],
-  updated: boolean
+  updated: boolean,
+  fatalError: boolean,
 }

--- a/src/main/types/CasesHeardPageData.ts
+++ b/src/main/types/CasesHeardPageData.ts
@@ -6,5 +6,6 @@ export interface CasesHeardPageData {
   courtAreasOfLaw: AreaOfLaw[],
   slug: string,
   errorMsg: Error[],
-  updated: Boolean
+  updated: Boolean,
+  fatalError: Boolean,
 }

--- a/src/main/types/Contact.ts
+++ b/src/main/types/Contact.ts
@@ -13,5 +13,6 @@ export interface ContactPageData {
   contacts: Contact[],
   contactTypes: SelectItem[],
   errorMsg: string,
-  updated: boolean
+  updated: boolean,
+  fatalError: boolean,
 }

--- a/src/main/types/CourtGeneralInfo.ts
+++ b/src/main/types/CourtGeneralInfo.ts
@@ -18,4 +18,5 @@ export interface CourtGeneralInfoData {
   errorMsg: string;
   updated: boolean;
   nameFieldError: string;
+  fatalError: boolean;
 }

--- a/src/main/types/CourtType.ts
+++ b/src/main/types/CourtType.ts
@@ -12,6 +12,7 @@ export interface CourtTypePageData {
   courtTypes: CourtTypeItem[],
   gbs? : string,
   dxCodes?: DxCode[];
+  fatalError: boolean;
 }
 
 export interface CourtTypeItem {

--- a/src/main/types/Email.ts
+++ b/src/main/types/Email.ts
@@ -13,5 +13,6 @@ export interface EmailData {
   emails: Email[],
   emailTypes: SelectItem[],
   errors: Error[],
-  updated: boolean
+  updated: boolean,
+  fatalError: boolean,
 }

--- a/src/main/types/Facility.ts
+++ b/src/main/types/Facility.ts
@@ -23,5 +23,6 @@ export interface FacilityPageData {
   updated: boolean,
   facilitiesTypes: SelectItem[],
   courtFacilities: Facility[],
-  requiresValidation: boolean
+  requiresValidation: boolean,
+  fatalError: boolean,
 }

--- a/src/main/types/LocalAuthority.ts
+++ b/src/main/types/LocalAuthority.ts
@@ -11,6 +11,7 @@ export interface LocalAuthoritiesAreaOfLaw {
   updated: boolean,
   isEnabled : boolean,
   courtAreasOfLaw: SelectItem[],
+  fatalError: boolean,
 }
 export interface LocalAuthoritiesPageData {
   errorMsg: string,

--- a/src/main/types/OpeningTime.ts
+++ b/src/main/types/OpeningTime.ts
@@ -11,5 +11,6 @@ export interface OpeningTimeData {
   opening_times: OpeningTime[],
   openingTimeTypes: SelectItem[],
   errors: Error[],
-  updated: boolean
+  updated: boolean,
+  fatalError: boolean,
 }

--- a/src/main/types/Postcode.ts
+++ b/src/main/types/Postcode.ts
@@ -10,5 +10,6 @@ export interface PostcodeData {
   searchValue: string,
   isEnabled : boolean,
   courtTypes: string[],
-  areasOfLaw: string[]
+  areasOfLaw: string[],
+  fatalError: boolean,
 }

--- a/src/main/types/SpoeAreaOfLawPageData.ts
+++ b/src/main/types/SpoeAreaOfLawPageData.ts
@@ -6,5 +6,6 @@ export interface SpoeAreaOfLawPageData {
   courtSpoeAreasOfLaw: SpoeAreaOfLaw[],
   slug: string,
   errorMsg: Error[],
-  updated: Boolean
+  updated: Boolean,
+  fatalError: Boolean
 }

--- a/src/main/views/courts/addNewCourt.njk
+++ b/src/main/views/courts/addNewCourt.njk
@@ -179,7 +179,8 @@
     {{ govukButton({
       text: "Add court",
       name: "saveNewCourt",
-      attributes: { href: redirectUrl, id: 'saveNewCourtBtn' }
+      attributes: { href: redirectUrl, id: 'saveNewCourtBtn' },
+      disabled: fatalError
     }) }}
   </form>
 {% endblock %}

--- a/src/main/views/courts/tabs/additionalLinksContent.njk
+++ b/src/main/views/courts/tabs/additionalLinksContent.njk
@@ -197,14 +197,18 @@
 
 {% endcall %}
 
+
 {{ govukButton({
   text: "Save",
-  name: "saveAdditionalLink"
+  name: "saveAdditionalLink",
+  disabled: fatalError
 }) }}
+
 
 {{ govukButton({
   text: "Add new additional link",
   name: "addAdditionalLink",
   type: "button",
-  classes: "govuk-button--secondary addAdditionalLink"
+  classes: "govuk-button--secondary addAdditionalLink",
+  disabled: fatalError
 }) }}

--- a/src/main/views/courts/tabs/applicationProgressionContent.njk
+++ b/src/main/views/courts/tabs/applicationProgressionContent.njk
@@ -266,12 +266,14 @@
 
 {{ govukButton({
   text: "Save",
-  name: "saveUpdate"
+  name: "saveUpdate",
+  disabled: fatalError
 }) }}
 
 {{ govukButton({
   text: "Add new application progression",
   name: "addNewUpdate",
   type: "button",
-  classes: "govuk-button--secondary addUpdate"
+  classes: "govuk-button--secondary addUpdate",
+  disabled: fatalError
 }) }}

--- a/src/main/views/courts/tabs/casesHeardContent.njk
+++ b/src/main/views/courts/tabs/casesHeardContent.njk
@@ -70,7 +70,8 @@
     {{ govukButton({
       text: "Update",
       name: "updateCasesHeard",
-      id: "updateCasesHeardSelect"
+      id: "updateCasesHeardSelect",
+      disabled : fatalError
     }) }}
   </div>
 {% endif %}

--- a/src/main/views/courts/tabs/emailsContent.njk
+++ b/src/main/views/courts/tabs/emailsContent.njk
@@ -219,7 +219,8 @@
 
 {{ govukButton({
   text: "Save",
-  name: "saveEmail"
+  name: "saveEmail",
+  disabled: fatalError
 }) }}
 
 
@@ -227,5 +228,6 @@
   text: "Add new email address",
   name: "addEmail",
   type: "button",
-  classes: "govuk-button--secondary addEmail"
+  classes: "govuk-button--secondary addEmail",
+  disabled: fatalError
 }) }}

--- a/src/main/views/courts/tabs/facilitiesContent.njk
+++ b/src/main/views/courts/tabs/facilitiesContent.njk
@@ -108,14 +108,16 @@
 
 {{ govukButton({
   text: "Save",
-  name: "saveFacilities"
+  name: "saveFacilities",
+  disabled: fatalError
 }) }}
 
 {{ govukButton({
   text: "Add new facility",
   name: "addFacility",
   type: "button",
-  classes: "govuk-button--secondary addFacility"
+  classes: "govuk-button--secondary addFacility",
+  disabled: fatalError
 }) }}
 
 

--- a/src/main/views/courts/tabs/generalContent.njk
+++ b/src/main/views/courts/tabs/generalContent.njk
@@ -158,5 +158,6 @@
 {{ govukButton({
   text: "Save",
   name: "saveGeneralInfo",
-  attributes: { id: 'saveGeneralInfoBtn'}
+  attributes: { id: 'saveGeneralInfoBtn'},
+  disabled: fatalError
 }) }}

--- a/src/main/views/courts/tabs/localAuthoritiesContent.njk
+++ b/src/main/views/courts/tabs/localAuthoritiesContent.njk
@@ -72,8 +72,8 @@
 
  {{ govukButton({
    text: "Save",
-   name: "saveLocalAuthorities"
-
+   name: "saveLocalAuthorities",
+   disabled: fatalError
  }) }}
 
 {% endif %}

--- a/src/main/views/courts/tabs/openingHoursContent.njk
+++ b/src/main/views/courts/tabs/openingHoursContent.njk
@@ -187,12 +187,14 @@
 
 {{ govukButton({
   text: "Save",
-  name: "saveOpeningTime"
+  name: "saveOpeningTime",
+  disabled : fatalError
 }) }}
 
 {{ govukButton({
   text: "Add new opening time",
   name: "addOpeningTime",
   type: "button",
-  classes: "govuk-button--secondary addOpeningTime"
+  classes: "govuk-button--secondary addOpeningTime",
+  disabled : fatalError
 }) }}

--- a/src/main/views/courts/tabs/phoneNumbersContent.njk
+++ b/src/main/views/courts/tabs/phoneNumbersContent.njk
@@ -260,12 +260,14 @@
 
 {{ govukButton({
   text: "Save",
-  name: "savePhoneNumbers"
+  name: "savePhoneNumbers",
+  disabled: fatalError
 }) }}
 
 {{ govukButton({
   text: "Add new phone number",
   name: "addPhoneNumber",
   type: "button",
-  classes: "govuk-button--secondary addPhoneNumber"
+  classes: "govuk-button--secondary addPhoneNumber",
+  disabled: fatalError
 }) }}

--- a/src/main/views/courts/tabs/postcodesContent.njk
+++ b/src/main/views/courts/tabs/postcodesContent.njk
@@ -71,7 +71,8 @@
     text: "Add",
     name: "addPostcodes",
     type: "button",
-    classes: "addPostcodes"
+    classes: "addPostcodes",
+    disabled: fatalError
   }) }}
 
   {% if postcodes|length %}
@@ -126,7 +127,8 @@
           text: "Move all selected to:",
           name: "movePostcodesButton",
           type: "button",
-          classes: "movePostcodesButton"
+          classes: "movePostcodesButton",
+          disabled: fatalError
         }) }}
       </div>
 
@@ -143,7 +145,8 @@
       text: "Delete all selected",
       name: "deletePostcodes",
       type: "button",
-      classes: "deletePostcodes govuk-button--warning"
+      classes: "deletePostcodes govuk-button--warning",
+      disabled: fatalError
     }) }}
 
   {% endif %}

--- a/src/main/views/courts/tabs/spoeContent.njk
+++ b/src/main/views/courts/tabs/spoeContent.njk
@@ -48,5 +48,6 @@
 
 {{ govukButton({
   text: "Update",
-  name: "saveSpoe"
+  name: "saveSpoe",
+  disabled: fatalError
 }) }}

--- a/src/main/views/courts/tabs/typesContent.njk
+++ b/src/main/views/courts/tabs/typesContent.njk
@@ -270,7 +270,8 @@
 
 {{ govukButton({
   text: "Save",
-  name: "saveCourtTypes"
+  name: "saveCourtTypes",
+  disabled: fatalError
 }) }}
 
 
@@ -280,7 +281,8 @@
   text: "Add new Dx code",
   name: "addDxCode",
   type: "button",
-  classes: "govuk-button--secondary addDxCode"
+  classes: "govuk-button--secondary addDxCode",
+  disabled: fatalError
 }) }}
 
 

--- a/src/test/unit/app/controller/courts/AdditionalLinksController.ts
+++ b/src/test/unit/app/controller/courts/AdditionalLinksController.ts
@@ -7,8 +7,8 @@ import {AdditionalLinksController} from '../../../../../main/app/controller/cour
 describe('AdditionalLinksController', () => {
 
   let mockApi: {
-    getCourtAdditionalLinks: () => Promise<AdditionalLink[]>,
-    updateCourtAdditionalLinks: () => Promise<AdditionalLink[]>
+    getCourtAdditionalLinks: () => Promise<AdditionalLink[]>;
+    updateCourtAdditionalLinks: () => Promise<AdditionalLink[]>;
   };
 
   const getLinks: () => AdditionalLink[] = () => [
@@ -45,7 +45,8 @@ describe('AdditionalLinksController', () => {
     const expectedResults: AdditionalLinkData = {
       links: linksWithEmptyEntry,
       updated: false,
-      errors: []
+      errors: [],
+      fatalError: false
     };
     expect(res.render).toBeCalledWith(additionalLinksPage, expectedResults);
   });
@@ -86,7 +87,8 @@ describe('AdditionalLinksController', () => {
     const expectedResults: AdditionalLinkData = {
       links: linksWithEmptyUrl,
       updated: false,
-      errors: [{text: controller.emptyUrlOrDisplayNameErrorMsg}]
+      errors: [{text: controller.emptyUrlOrDisplayNameErrorMsg}],
+      fatalError: false
     };
     expect(res.render).toBeCalledWith(additionalLinksPage, expectedResults);
   });
@@ -111,7 +113,8 @@ describe('AdditionalLinksController', () => {
     const expectedResults: AdditionalLinkData = {
       links: linksWithEmptyDisplayName,
       updated: false,
-      errors: [{text: controller.emptyUrlOrDisplayNameErrorMsg}]
+      errors: [{text: controller.emptyUrlOrDisplayNameErrorMsg}],
+      fatalError: false
     };
     expect(res.render).toBeCalledWith(additionalLinksPage, expectedResults);
   });
@@ -136,7 +139,8 @@ describe('AdditionalLinksController', () => {
     const expectedResults: AdditionalLinkData = {
       links: linksWithUrlInvalidFormat,
       updated: false,
-      errors: [{text: controller.invalidUrlFormatErrorMsg}]
+      errors: [{text: controller.invalidUrlFormatErrorMsg}],
+      fatalError: false
     };
     expect(res.render).toBeCalledWith(additionalLinksPage, expectedResults);
   });
@@ -162,7 +166,8 @@ describe('AdditionalLinksController', () => {
     const expectedResults: AdditionalLinkData = {
       links: linksWithDuplicatedUrl,
       updated: false,
-      errors: [{text: controller.urlDuplicatedErrorMsg}]
+      errors: [{text: controller.urlDuplicatedErrorMsg}],
+      fatalError: false
     };
     expect(res.render).toBeCalledWith(additionalLinksPage, expectedResults);
   });
@@ -188,7 +193,8 @@ describe('AdditionalLinksController', () => {
     const expectedResults: AdditionalLinkData = {
       links: linksWithDuplicatedUrl,
       updated: false,
-      errors: [{text: controller.displayNameDuplicatedErrorMsg}]
+      errors: [{text: controller.displayNameDuplicatedErrorMsg}],
+      fatalError: false
     };
     expect(res.render).toBeCalledWith(additionalLinksPage, expectedResults);
   });
@@ -220,7 +226,8 @@ describe('AdditionalLinksController', () => {
         {text: controller.emptyUrlOrDisplayNameErrorMsg},
         {text: controller.invalidUrlFormatErrorMsg},
         {text: controller.urlDuplicatedErrorMsg}
-      ]
+      ],
+      fatalError: false
     };
     expect(res.render).toBeCalledWith(additionalLinksPage, expectedResults);
   });
@@ -241,7 +248,8 @@ describe('AdditionalLinksController', () => {
     const expectedResults: AdditionalLinkData = {
       links: linksWithEmptyEntry,
       updated: false,
-      errors: [{text: controller.updateAdditionalLinksErrorMsg}]
+      errors: [{text: controller.updateAdditionalLinksErrorMsg}],
+      fatalError: false
     };
     expect(res.render).toBeCalledWith(additionalLinksPage, expectedResults);
   });
@@ -258,7 +266,8 @@ describe('AdditionalLinksController', () => {
     const expectedResults: AdditionalLinkData = {
       links: null,
       updated: false,
-      errors: [{text: controller.getAdditionalLinksErrorMsg}]
+      errors: [{text: controller.getAdditionalLinksErrorMsg}],
+      fatalError: true
     };
     expect(res.render).toBeCalledWith(additionalLinksPage, expectedResults);
   });
@@ -279,7 +288,8 @@ describe('AdditionalLinksController', () => {
     const expectedResults: AdditionalLinkData = {
       links: linksWithEmptyEntry,
       updated: false,
-      errors: [{text: controller.updateAdditionalLinksErrorMsg}]
+      errors: [{text: controller.updateAdditionalLinksErrorMsg}],
+      fatalError: false
     };
     expect(res.render).toBeCalledWith(additionalLinksPage, expectedResults);
   });

--- a/src/test/unit/app/controller/courts/ApplicationProgressionController.ts
+++ b/src/test/unit/app/controller/courts/ApplicationProgressionController.ts
@@ -8,9 +8,9 @@ import {CourtGeneralInfo} from '../../../../../main/types/CourtGeneralInfo';
 describe('ApplicationProgressionController', () => {
 
   let mockApi: {
-    getApplicationUpdates: () => Promise<ApplicationProgression[]>,
-    updateApplicationUpdates: () => Promise<ApplicationProgression[]>,
-    getGeneralInfo: () => Promise<CourtGeneralInfo>
+    getApplicationUpdates: () => Promise<ApplicationProgression[]>;
+    updateApplicationUpdates: () => Promise<ApplicationProgression[]>;
+    getGeneralInfo: () => Promise<CourtGeneralInfo>;
   };
 
   const controller = new ApplicationProgressionController();
@@ -67,7 +67,8 @@ describe('ApplicationProgressionController', () => {
       application_progression: updatesWithEmptyEntry,
       isEnabled: courtGeneralInfo.service_centre,
       errors: [],
-      updated: false
+      updated: false,
+      fatalError: false
     };
     expect(res.render).toBeCalledWith(applicationUpdatesPage, expectedResults);
   });
@@ -87,7 +88,8 @@ describe('ApplicationProgressionController', () => {
       application_progression: null,
       isEnabled: courtGeneralInfo.service_centre,
       updated: false,
-      errors: [{text: controller.getApplicationUpdatesErrorMsg}]
+      errors: [{text: controller.getApplicationUpdatesErrorMsg}],
+      fatalError: true
     };
     expect(res.render).toBeCalledWith(applicationUpdatesPage, expectedResults);
   });
@@ -161,7 +163,8 @@ describe('ApplicationProgressionController', () => {
         {text: controller.doubleInputErrorMsg},
         {text: controller.invalidEmailFormatErrorMsg},
         {text: controller.invalidUrlFormatErrorMsg}
-      ]
+      ],
+      fatalError: false
     };
     expect(res.render).toBeCalledWith(applicationUpdatesPage, expectedResults);
   });
@@ -186,7 +189,8 @@ describe('ApplicationProgressionController', () => {
       application_progression: postedUpdates,
       isEnabled: true,
       errors: [{text: controller.emailDuplicatedErrorMsg}],
-      updated: false
+      updated: false,
+      fatalError: false
     };
 
     expect(res.render).toBeCalledWith(applicationUpdatesPage, expectedResults);

--- a/src/test/unit/app/controller/courts/CasesHeardController.ts
+++ b/src/test/unit/app/controller/courts/CasesHeardController.ts
@@ -7,9 +7,9 @@ import {CasesHeardController} from '../../../../../main/app/controller/courts/Ca
 describe('CasesHeardController', () => {
 
   let mockApi: {
-    getAllAreasOfLaw: () => Promise<AreaOfLaw[]>,
-    getCourtAreasOfLaw: () => Promise<AreaOfLaw[]>,
-    updateCourtAreasOfLaw: () => Promise<AreaOfLaw[]>};
+    getAllAreasOfLaw: () => Promise<AreaOfLaw[]>;
+    getCourtAreasOfLaw: () => Promise<AreaOfLaw[]>;
+    updateCourtAreasOfLaw: () => Promise<AreaOfLaw[]>;};
 
   const testSlug = 'plymouth-combined-court';
 
@@ -74,7 +74,8 @@ describe('CasesHeardController', () => {
       courtAreasOfLaw: getCourtAreasOfLawData,
       slug: testSlug,
       errorMsg: [],
-      updated: false
+      updated: false,
+      fatalError: false
     });
     expect(mockApi.getAllAreasOfLaw).toBeCalled();
     expect(mockApi.getCourtAreasOfLaw).toBeCalledWith(testSlug);
@@ -96,7 +97,8 @@ describe('CasesHeardController', () => {
       courtAreasOfLaw: getCourtAreasOfLawData,
       slug: testSlug,
       errorMsg: [{text: controller.getAreasOfLawErrorMsg}],
-      updated: false
+      updated: false,
+      fatalError: true
     });
     expect(mockApi.getAllAreasOfLaw).toBeCalled();
     expect(mockApi.getCourtAreasOfLaw).toBeCalledWith(testSlug);
@@ -118,7 +120,8 @@ describe('CasesHeardController', () => {
       courtAreasOfLaw: null,
       slug: testSlug,
       errorMsg: [{text: controller.getCourtAreasOfLawErrorMsg}],
-      updated: false
+      updated: false,
+      fatalError: true
     });
     expect(mockApi.getAllAreasOfLaw).toBeCalled();
     expect(mockApi.getCourtAreasOfLaw).toBeCalledWith(testSlug);
@@ -142,7 +145,8 @@ describe('CasesHeardController', () => {
       courtAreasOfLaw: updatedCourtAreasOfLawData,
       slug: testSlug,
       errorMsg: [],
-      updated: true
+      updated: true,
+      fatalError: false
     });
     expect(mockApi.updateCourtAreasOfLaw).toBeCalledWith(testSlug, updatedCourtAreasOfLawData);
   });
@@ -168,7 +172,8 @@ describe('CasesHeardController', () => {
       courtAreasOfLaw: updatedCourtAreasOfLawData,
       slug: testSlug,
       errorMsg: [{text: controller.putCourtAreasOfLawErrorMsg}],
-      updated: false
+      updated: false,
+      fatalError: false
     });
     expect(mockApi.updateCourtAreasOfLaw).toBeCalledWith(testSlug, updatedCourtAreasOfLawData);
   });
@@ -193,7 +198,8 @@ describe('CasesHeardController', () => {
       courtAreasOfLaw: updatedCourtAreasOfLawData,
       slug: testSlug,
       errorMsg: [{text: controller.putCourtAreasOfLawErrorMsg}],
-      updated: false
+      updated: false,
+      fatalError: false
     });
     expect(mockApi.updateCourtAreasOfLaw).not.toBeCalled();
   });

--- a/src/test/unit/app/controller/courts/ContactsController.ts
+++ b/src/test/unit/app/controller/courts/ContactsController.ts
@@ -9,9 +9,9 @@ import {CSRF} from '../../../../../main/modules/csrf';
 describe('ContactsController', () => {
 
   let mockApi: {
-    getContacts: () => Promise<Contact[]>,
-    updateContacts: () => Promise<Contact[]>,
-    getContactTypes: () => Promise<ContactType[]> };
+    getContacts: () => Promise<Contact[]>;
+    updateContacts: () => Promise<Contact[]>;
+    getContactTypes: () => Promise<ContactType[]>; };
 
   const getContacts: () => Contact[] = () => [
     { 'type_id': 1, number: '0123 456 7890', fax: false, explanation: 'Exp 1', 'explanation_cy': 'Exp_cy 1', isNew: false },
@@ -61,7 +61,8 @@ describe('ContactsController', () => {
       contacts: getContactsWithEmptyEntry(),
       contactTypes: expectedSelectItems,
       updated: false,
-      errorMsg: ''
+      errorMsg: '',
+      fatalError: false
     };
     expect(res.render).toBeCalledWith('courts/tabs/phoneNumbersContent', expectedResults);
   });
@@ -164,7 +165,8 @@ describe('ContactsController', () => {
       contacts: postedContacts,
       contactTypes: expectedSelectItems,
       updated: false,
-      errorMsg: controller.updateErrorMsg
+      errorMsg: controller.updateErrorMsg,
+      fatalError: false
     };
     expect(res.render).toBeCalledWith('courts/tabs/phoneNumbersContent', expectedResults);
   });
@@ -184,7 +186,8 @@ describe('ContactsController', () => {
       contacts: null,
       contactTypes: expectedSelectItems,
       updated: false,
-      errorMsg: controller.getContactsErrorMsg
+      errorMsg: controller.getContactsErrorMsg,
+      fatalError: true
     };
     expect(res.render).toBeCalledWith('courts/tabs/phoneNumbersContent', expectedResults);
   });
@@ -204,7 +207,8 @@ describe('ContactsController', () => {
       contacts: getContactsWithEmptyEntry(),
       contactTypes: [],
       updated: false,
-      errorMsg: controller.getContactTypesErrorMsg
+      errorMsg: controller.getContactTypesErrorMsg,
+      fatalError: true
     };
     expect(res.render).toBeCalledWith('courts/tabs/phoneNumbersContent', expectedResults);
   });
@@ -234,7 +238,8 @@ describe('ContactsController', () => {
       contacts: postedContacts,
       contactTypes: expectedSelectItems,
       updated: false,
-      errorMsg: controller.updateErrorMsg
+      errorMsg: controller.updateErrorMsg,
+      fatalError: false
     };
     expect(res.render).toBeCalledWith('courts/tabs/phoneNumbersContent', expectedResults);
   });

--- a/src/test/unit/app/controller/courts/CourtFacilitiesController.ts
+++ b/src/test/unit/app/controller/courts/CourtFacilitiesController.ts
@@ -323,7 +323,7 @@ describe('FacilitiesController', () => {
       facilitiesTypes: expectedSelectItems,
       courtFacilities: expectedFacilities,
       requiresValidation: true,
-      fatalError: true
+      fatalError: false
     };
     expect(res.render).toBeCalledWith('courts/tabs/facilitiesContent', expectedResults);
   });
@@ -363,7 +363,7 @@ describe('FacilitiesController', () => {
       facilitiesTypes: expectedSelectItems,
       courtFacilities: expectedFacilities,
       requiresValidation: true,
-      fatalError: true
+      fatalError: false
     };
 
     expect(res.render).toBeCalledWith('courts/tabs/facilitiesContent', expectedResults);
@@ -390,7 +390,7 @@ describe('FacilitiesController', () => {
       facilitiesTypes: expectedSelectItems,
       courtFacilities: expectedCourtFacilities,
       requiresValidation: false,
-      fatalError: true
+      fatalError: false
     };
     expect(res.render).toBeCalledWith('courts/tabs/facilitiesContent', expectedResults);
   });

--- a/src/test/unit/app/controller/courts/CourtFacilitiesController.ts
+++ b/src/test/unit/app/controller/courts/CourtFacilitiesController.ts
@@ -8,9 +8,9 @@ import {Facility, FacilityPageData, FacilityType} from '../../../../../main/type
 describe('FacilitiesController', () => {
 
   let mockApi: {
-    getAllFacilityTypes: () => Promise<FacilityType[]>,
-    getCourtFacilities: () => Promise<Facility[]>,
-    updateCourtFacilities: () => Promise<Facility[]> };
+    getAllFacilityTypes: () => Promise<FacilityType[]>;
+    getCourtFacilities: () => Promise<Facility[]>;
+    updateCourtFacilities: () => Promise<Facility[]>;};
 
   const getFacilities: () => Facility[] = () => [
     { id: 1, description:'description1', descriptionCy:'descriptionCy1', isNew: false },
@@ -74,7 +74,8 @@ describe('FacilitiesController', () => {
       updated: false,
       facilitiesTypes: expectedSelectItems,
       courtFacilities: expectedCourtFacilities,
-      requiresValidation: true
+      requiresValidation: true,
+      fatalError: false
     };
     expect(res.render).toBeCalledWith('courts/tabs/facilitiesContent', expectedResults);
   });
@@ -210,7 +211,8 @@ describe('FacilitiesController', () => {
       updated: false,
       facilitiesTypes: expectedSelectItems,
       courtFacilities: postedFacilities,
-      requiresValidation: true
+      requiresValidation: true,
+      fatalError: false
     };
 
     await controller.put(req, res);
@@ -233,7 +235,8 @@ describe('FacilitiesController', () => {
       updated: false,
       facilitiesTypes: expectedSelectItems,
       courtFacilities: null,
-      requiresValidation: true
+      requiresValidation: true,
+      fatalError: true
     };
     await controller.get(req, res);
 
@@ -258,7 +261,8 @@ describe('FacilitiesController', () => {
       updated: false,
       facilitiesTypes: [],
       courtFacilities: expectedCourtFacilities,
-      requiresValidation: true
+      requiresValidation: true,
+      fatalError : true
     };
     expect(res.render).toBeCalledWith('courts/tabs/facilitiesContent', expectedResults);
   });
@@ -282,7 +286,8 @@ describe('FacilitiesController', () => {
       updated: false,
       facilitiesTypes: expectedSelectItems,
       courtFacilities: postedFacilities,
-      requiresValidation: true
+      requiresValidation: true,
+      fatalError: false
     };
     expect(res.render).toBeCalledWith('courts/tabs/facilitiesContent', expectedResults);
   });
@@ -317,7 +322,8 @@ describe('FacilitiesController', () => {
       updated: false,
       facilitiesTypes: expectedSelectItems,
       courtFacilities: expectedFacilities,
-      requiresValidation: true
+      requiresValidation: true,
+      fatalError: true
     };
     expect(res.render).toBeCalledWith('courts/tabs/facilitiesContent', expectedResults);
   });
@@ -356,7 +362,8 @@ describe('FacilitiesController', () => {
       updated: false,
       facilitiesTypes: expectedSelectItems,
       courtFacilities: expectedFacilities,
-      requiresValidation: true
+      requiresValidation: true,
+      fatalError: true
     };
 
     expect(res.render).toBeCalledWith('courts/tabs/facilitiesContent', expectedResults);
@@ -382,7 +389,8 @@ describe('FacilitiesController', () => {
       updated: false,
       facilitiesTypes: expectedSelectItems,
       courtFacilities: expectedCourtFacilities,
-      requiresValidation: false
+      requiresValidation: false,
+      fatalError: true
     };
     expect(res.render).toBeCalledWith('courts/tabs/facilitiesContent', expectedResults);
   });

--- a/src/test/unit/app/controller/courts/CourtTypesController.ts
+++ b/src/test/unit/app/controller/courts/CourtTypesController.ts
@@ -10,9 +10,9 @@ import {CourtTypesAndCodes} from '../../../../../main/types/CourtTypesAndCodes';
 describe ( 'CourtTypesController', () =>{
 
   let mockApi: {
-    getCourtTypes: () => Promise<CourtType[]>,
-    getCourtTypesAndCodes: () => Promise<CourtTypesAndCodes>,
-    updateCourtTypesAndCodes: () => Promise<CourtTypesAndCodes> };
+    getCourtTypes: () => Promise<CourtType[]>;
+    getCourtTypesAndCodes: () => Promise<CourtTypesAndCodes>;
+    updateCourtTypesAndCodes: () => Promise<CourtTypesAndCodes>;};
 
 
   const courtTypes: CourtType[] = [
@@ -73,7 +73,8 @@ describe ( 'CourtTypesController', () =>{
       errorMsg: '',
       courtTypes: courtTypeItems,
       gbs:courtTypesAndCodes.gbsCode,
-      dxCodes:courtTypesAndCodes.dxCodes
+      dxCodes:courtTypesAndCodes.dxCodes,
+      fatalError: false
     };
 
     expect(res.render).toBeCalledWith('courts/tabs/typesContent', expectedResults);
@@ -259,7 +260,8 @@ describe ( 'CourtTypesController', () =>{
         { code: '123', explanation: 'explanation', explanationCy: 'explanationCy', isNew: false, isDuplicated: true },
         { code: '123', explanation: 'explanation', explanationCy: 'explanationCy', isNew: false, isDuplicated: true },
         { code: null, explanation: null, explanationCy: null, isNew: true }
-      ]
+      ],
+      fatalError: false
     };
     expect(res.render).toBeCalledWith('courts/tabs/typesContent', expectedResults);
   });
@@ -305,7 +307,8 @@ describe ( 'CourtTypesController', () =>{
       dxCodes:[
         { code: '', explanation: 'explanation', explanationCy: 'explanationCy', isNew: false,},
         { code: null, explanation: null, explanationCy: null, isNew: true }
-      ]
+      ],
+      fatalError: false
     };
     expect(res.render).toBeCalledWith('courts/tabs/typesContent', expectedResults);
   });
@@ -362,7 +365,8 @@ describe ( 'CourtTypesController', () =>{
       errorMsg: controller.getCourtTypesAndCodesErrorMsg,
       courtTypes: [],
       gbs:null,
-      dxCodes:[]
+      dxCodes:[],
+      fatalError: true
     };
     expect(res.render).toBeCalledWith('courts/tabs/typesContent', expectedResults);
   });
@@ -385,7 +389,8 @@ describe ( 'CourtTypesController', () =>{
       errorMsg: controller.getCourtTypesErrorMsg,
       courtTypes: [],
       gbs: courtTypesAndCodes.gbsCode,
-      dxCodes: courtTypesAndCodes.dxCodes
+      dxCodes: courtTypesAndCodes.dxCodes,
+      fatalError: true
     };
     expect(res.render).toBeCalledWith('courts/tabs/typesContent', expectedResults);
   });

--- a/src/test/unit/app/controller/courts/CourtsSpoeController.ts
+++ b/src/test/unit/app/controller/courts/CourtsSpoeController.ts
@@ -7,9 +7,9 @@ import {CourtSpoeController} from '../../../../../main/app/controller/courts/Cou
 describe('CourtsSpoeController', () => {
 
   let mockApi: {
-    getAllSpoeAreasOfLaw: () => Promise<SpoeAreaOfLaw[]>,
-    getCourtSpoeAreasOfLaw: () => Promise<SpoeAreaOfLaw[]>,
-    updateCourtSpoeAreasOfLaw: () => Promise<SpoeAreaOfLaw[]>};
+    getAllSpoeAreasOfLaw: () => Promise<SpoeAreaOfLaw[]>;
+    getCourtSpoeAreasOfLaw: () => Promise<SpoeAreaOfLaw[]>;
+    updateCourtSpoeAreasOfLaw: () => Promise<SpoeAreaOfLaw[]>;};
 
   const testSlug = 'plymouth-combined-court';
 
@@ -68,7 +68,8 @@ describe('CourtsSpoeController', () => {
       courtSpoeAreasOfLaw: getCourtSpoeAreasOfLawData,
       slug: testSlug,
       errorMsg: [],
-      updated: false
+      updated: false,
+      fatalError: false
     });
     expect(mockApi.getAllSpoeAreasOfLaw).toBeCalled();
     expect(mockApi.getCourtSpoeAreasOfLaw).toBeCalledWith(testSlug);
@@ -90,7 +91,8 @@ describe('CourtsSpoeController', () => {
       courtSpoeAreasOfLaw: getCourtSpoeAreasOfLawData,
       slug: testSlug,
       errorMsg: [{text: controller.getSpoeAreasOfLawErrorMsg}],
-      updated: false
+      updated: false,
+      fatalError: true
     });
     expect(mockApi.getAllSpoeAreasOfLaw).toBeCalled();
     expect(mockApi.getCourtSpoeAreasOfLaw).toBeCalledWith(testSlug);
@@ -112,7 +114,8 @@ describe('CourtsSpoeController', () => {
       courtSpoeAreasOfLaw: null,
       slug: testSlug,
       errorMsg: [{text: controller.getCourtSpoeAreasOfLawErrorMsg}],
-      updated: false
+      updated: false,
+      fatalError: true
     });
     expect(mockApi.getAllSpoeAreasOfLaw).toBeCalled();
     expect(mockApi.getCourtSpoeAreasOfLaw).toBeCalledWith(testSlug);
@@ -137,7 +140,8 @@ describe('CourtsSpoeController', () => {
       courtSpoeAreasOfLaw: updatedCourtSpoeAreasOfLawData,
       slug: testSlug,
       errorMsg: [],
-      updated: true
+      updated: true,
+      fatalError: false
     });
     expect(mockApi.updateCourtSpoeAreasOfLaw).toBeCalledWith(testSlug, updatedCourtSpoeAreasOfLawData );
   });
@@ -163,7 +167,8 @@ describe('CourtsSpoeController', () => {
       courtSpoeAreasOfLaw: updatedCourtSpoeAreasOfLawData,
       slug: testSlug,
       errorMsg: [{text: controller.putCourtSpoeAreasOfLawErrorMsg}],
-      updated: false
+      updated: false,
+      fatalError: false
     });
     expect(mockApi.updateCourtSpoeAreasOfLaw).toBeCalledWith(testSlug, updatedCourtSpoeAreasOfLawData);
   });
@@ -188,7 +193,8 @@ describe('CourtsSpoeController', () => {
       courtSpoeAreasOfLaw: updatedCourtSpoeAreasOfLawData,
       slug: testSlug,
       errorMsg: [{text: controller.putCourtSpoeAreasOfLawErrorMsg}],
-      updated: false
+      updated: false,
+      fatalError: false
     });
     expect(mockApi.updateCourtSpoeAreasOfLaw).not.toBeCalled();
   });

--- a/src/test/unit/app/controller/courts/EmailsController.ts
+++ b/src/test/unit/app/controller/courts/EmailsController.ts
@@ -9,9 +9,9 @@ import {CSRF} from '../../../../../main/modules/csrf';
 describe('EmailsController', () => {
 
   let mockApi: {
-    getEmails: () => Promise<Email[]>,
-    updateEmails: () => Promise<Email[]>,
-    getEmailTypes: () => Promise<EmailType[]> };
+    getEmails: () => Promise<Email[]>;
+    updateEmails: () => Promise<Email[]>;
+    getEmailTypes: () => Promise<EmailType[]>; };
 
   const testEmail1 = 'abc@test.com';
   const testEmail2 = 'abc@test2.com';
@@ -91,7 +91,8 @@ describe('EmailsController', () => {
       emails: emailsWithEmptyEntry,
       emailTypes: expectedSelectItems,
       updated: false,
-      errors: []
+      errors: [],
+      fatalError: false
     };
     expect(res.render).toBeCalledWith('courts/tabs/emailsContent', expectedResults);
   });
@@ -180,7 +181,8 @@ describe('EmailsController', () => {
       emails: emailsInvalidSyntax,
       emailTypes: expectedSelectItems,
       updated: false,
-      errors: [{text: controller.updateErrorMsg}]
+      errors: [{text: controller.updateErrorMsg}],
+      fatalError: false
     };
     expect(mockApi.updateEmails).not.toBeCalled();
     expect(res.render).toBeCalledWith('courts/tabs/emailsContent', expectedResults);
@@ -218,7 +220,8 @@ describe('EmailsController', () => {
         emails: postedEmails,
         emailTypes: expectedSelectItems,
         updated: false,
-        errors: [{text: controller.getEmailAddressFormatErrorMsg}]
+        errors: [{text: controller.getEmailAddressFormatErrorMsg}],
+        fatalError: false
       };
       expect(res.render).toBeCalledWith('courts/tabs/emailsContent', expectedResults);
     });
@@ -239,7 +242,8 @@ describe('EmailsController', () => {
       emails: null,
       emailTypes: expectedSelectItems,
       updated: false,
-      errors: [{text: controller.getEmailsErrorMsg}]
+      errors: [{text: controller.getEmailsErrorMsg}],
+      fatalError: true
     };
     expect(res.render).toBeCalledWith('courts/tabs/emailsContent', expectedResults);
   });
@@ -259,7 +263,8 @@ describe('EmailsController', () => {
       emails: emailsWithEmptyEntry,
       emailTypes: [],
       updated: false,
-      errors: [{text: controller.getEmailTypesErrorMsg}]
+      errors: [{text: controller.getEmailTypesErrorMsg}],
+      fatalError: true
     };
     expect(res.render).toBeCalledWith('courts/tabs/emailsContent', expectedResults);
   });
@@ -282,7 +287,8 @@ describe('EmailsController', () => {
       'emails': postedEmails,
       emailTypes: expectedSelectItems,
       updated: false,
-      errors: [{text: controller.emailDuplicatedErrorMsg}]
+      errors: [{text: controller.emailDuplicatedErrorMsg}],
+      fatalError: false
     };
     expect(res.render).toBeCalledWith('courts/tabs/emailsContent', expectedResults);
   });
@@ -313,7 +319,8 @@ describe('EmailsController', () => {
         {text: controller.emptyTypeOrAddressErrorMsg},
         {text: controller.getEmailAddressFormatErrorMsg},
         {text: controller.emailDuplicatedErrorMsg}
-      ]
+      ],
+      fatalError: false
     };
     expect(res.render).toBeCalledWith('courts/tabs/emailsContent', expectedResults);
   });

--- a/src/test/unit/app/controller/courts/GeneralInfoController.ts
+++ b/src/test/unit/app/controller/courts/GeneralInfoController.ts
@@ -7,8 +7,8 @@ import {CSRF} from '../../../../../main/modules/csrf';
 describe('GeneralInfoController', () => {
 
   let mockApi: {
-    getGeneralInfo: () => Promise<CourtGeneralInfo>,
-    updateGeneralInfo: () => Promise<CourtGeneralInfo>
+    getGeneralInfo: () => Promise<CourtGeneralInfo>;
+    updateGeneralInfo: () => Promise<CourtGeneralInfo>;
   };
 
   const courtGeneralInfo: CourtGeneralInfo = {
@@ -138,7 +138,8 @@ describe('GeneralInfoController', () => {
       generalInfo: courtGeneralInfo,
       errorMsg: '',
       updated: false,
-      nameFieldError: ''
+      nameFieldError: '',
+      fatalError: false
     };
 
     expect(res.render).toBeCalledWith('courts/tabs/generalContent', expectedResult);
@@ -180,7 +181,8 @@ describe('GeneralInfoController', () => {
       },
       errorMsg: controller.updateGeneralInfoErrorMsg,
       updated: false,
-      nameFieldError: ''
+      nameFieldError: '',
+      fatalError: false
     } as CourtGeneralInfoData;
     await controller.put(req, res);
 
@@ -207,7 +209,8 @@ describe('GeneralInfoController', () => {
       },
       errorMsg: controller.updateGeneralInfoErrorMsg,
       updated: false,
-      nameFieldError: controller.blankNameErrorMsg
+      nameFieldError: controller.blankNameErrorMsg,
+      fatalError: false
     } as CourtGeneralInfoData;
     await controller.put(req, res);
 
@@ -231,7 +234,8 @@ describe('GeneralInfoController', () => {
       generalInfo: null,
       errorMsg: controller.getGeneralInfoErrorMsg,
       updated: false,
-      nameFieldError: ''
+      nameFieldError: '',
+      fatalError: true
     };
 
     expect(res.render).toBeCalledWith('courts/tabs/generalContent', expectedResult);
@@ -253,7 +257,8 @@ describe('GeneralInfoController', () => {
       generalInfo: courtGeneralInfo,
       errorMsg: controller.updateGeneralInfoErrorMsg,
       updated: false,
-      nameFieldError: ''
+      nameFieldError: '',
+      fatalError: false
     };
 
     expect(res.render).toBeCalledWith('courts/tabs/generalContent', expectedResult);
@@ -272,7 +277,8 @@ describe('GeneralInfoController', () => {
       generalInfo: courtGeneralInfoInvalidCharacters,
       errorMsg: controller.updateGeneralInfoErrorMsg,
       updated: false,
-      nameFieldError: controller.specialCharacterErrorMsg
+      nameFieldError: controller.specialCharacterErrorMsg,
+      fatalError: false
     };
 
     expect(res.render).toBeCalledWith('courts/tabs/generalContent', expectedResult);
@@ -291,7 +297,8 @@ describe('GeneralInfoController', () => {
       generalInfo: courtGeneralInfoTooManyCharsForIntroParagraph,
       errorMsg: controller.updateIntroParagraphErrorMsg,
       updated: false,
-      nameFieldError: ''
+      nameFieldError: '',
+      fatalError: false
     };
 
     expect(res.render).toBeCalledWith('courts/tabs/generalContent', expectedResult);
@@ -313,7 +320,8 @@ describe('GeneralInfoController', () => {
       generalInfo: courtGeneralInfo,
       errorMsg: controller.updateDuplicateGeneralInfoErrorMsg + courtGeneralInfo.name,
       updated: false,
-      nameFieldError: controller.duplicateNameErrorMsg
+      nameFieldError: controller.duplicateNameErrorMsg,
+      fatalError: false
     };
 
     expect(res.render).toBeCalledWith('courts/tabs/generalContent', expectedResult);
@@ -332,7 +340,8 @@ describe('GeneralInfoController', () => {
       generalInfo: courtGeneralInfoOverCharacterLimit,
       errorMsg: controller.updateAlertErrorMsg,
       updated: false,
-      nameFieldError: ''
+      nameFieldError: '',
+      fatalError: false
     };
 
     expect(res.render).toBeCalledWith('courts/tabs/generalContent', expectedResult);

--- a/src/test/unit/app/controller/courts/LocalAuthoritiesController.ts
+++ b/src/test/unit/app/controller/courts/LocalAuthoritiesController.ts
@@ -15,15 +15,15 @@ import {CourtTypesAndCodes} from '../../../../../main/types/CourtTypesAndCodes';
 describe ( 'LocalAuthoritiesController', () => {
 
   let mockApi: {
-    getCourtAreasOfLaw: () => Promise<AreaOfLaw[]>,
-    getCourtTypesAndCodes: () => Promise<CourtTypesAndCodes>,
-    getAllLocalAuthorities: () => Promise<LocalAuthority[]>,
-    getCourtLocalAuthoritiesByAreaOfLaw: () => Promise<LocalAuthority[]>,
-    updateCourtLocalAuthoritiesByAreaOfLaw: () => Promise<LocalAuthority[]> };
+    getCourtAreasOfLaw: () => Promise<AreaOfLaw[]>;
+    getCourtTypesAndCodes: () => Promise<CourtTypesAndCodes>;
+    getAllLocalAuthorities: () => Promise<LocalAuthority[]>;
+    getCourtLocalAuthoritiesByAreaOfLaw: () => Promise<LocalAuthority[]>;
+    updateCourtLocalAuthoritiesByAreaOfLaw: () => Promise<LocalAuthority[]>;};
 
   let mockApiAreaOfLaw: {
-    getCourtAreasOfLaw: () => Promise<AreaOfLaw[]>,
-    getCourtTypesAndCodes: () => Promise<CourtTypesAndCodes>
+    getCourtAreasOfLaw: () => Promise<AreaOfLaw[]>;
+    getCourtTypesAndCodes: () => Promise<CourtTypesAndCodes>;
   };
 
   const courtAreasOfLaw: AreaOfLaw[] = [
@@ -144,7 +144,8 @@ describe ( 'LocalAuthoritiesController', () => {
       updated: false,
       errorMsg: '',
       isEnabled: true,
-      courtAreasOfLaw: areasOfLawItems
+      courtAreasOfLaw: areasOfLawItems,
+      fatalError: false,
     };
 
     expect(res.render).toBeCalledWith('courts/tabs/localAuthoritiesContent', expectedResults);
@@ -166,7 +167,8 @@ describe ( 'LocalAuthoritiesController', () => {
       updated: false,
       errorMsg: controller.getCourtAreasOfLawErrorMsg,
       isEnabled: true,
-      courtAreasOfLaw: []
+      courtAreasOfLaw: [],
+      fatalError: true
     };
     expect(res.render).toBeCalledWith('courts/tabs/localAuthoritiesContent', expectedResults);
   });
@@ -187,7 +189,8 @@ describe ( 'LocalAuthoritiesController', () => {
       updated: false,
       errorMsg: controller.getCourtTypesErrorMsg,
       isEnabled: false,
-      courtAreasOfLaw: areasOfLawItems
+      courtAreasOfLaw: areasOfLawItems,
+      fatalError: true
     };
     expect(res.render).toBeCalledWith('courts/tabs/localAuthoritiesContent', expectedResults);
   });
@@ -210,7 +213,8 @@ describe ( 'LocalAuthoritiesController', () => {
       updated: false,
       errorMsg: controller.familyAreaOfLawErrorMsg,
       isEnabled: true,
-      courtAreasOfLaw: []
+      courtAreasOfLaw: [],
+      fatalError: true,
     };
     expect(res.render).toBeCalledWith('courts/tabs/localAuthoritiesContent', expectedResults);
   });

--- a/src/test/unit/app/controller/courts/NewCourtController.ts
+++ b/src/test/unit/app/controller/courts/NewCourtController.ts
@@ -10,8 +10,8 @@ import {ServiceAreaCourt} from '../../../../../main/types/ServiceAreaCourt';
 describe('NewCourtController', () => {
 
   let mockApi: {
-    addCourt: () => Promise<Court>,
-    getAllServiceAreas: () => Promise<ServiceArea[]>
+    addCourt: () => Promise<Court>;
+    getAllServiceAreas: () => Promise<ServiceArea[]>;
   };
 
   const controller = new NewCourtController();
@@ -86,7 +86,8 @@ describe('NewCourtController', () => {
       'redirectUrl': '',
       'serviceAreaChecked': false,
       'allServiceAreas': getAllServiceAreas(),
-      'serviceAreas': []
+      'serviceAreas': [],
+      'fatalError': false,
     });
   });
 
@@ -116,7 +117,8 @@ describe('NewCourtController', () => {
       'redirectUrl': '',
       'serviceAreaChecked': false,
       'allServiceAreas': getAllServiceAreas(),
-      'serviceAreas': []
+      'serviceAreas': [],
+      'fatalError': false,
     });
     expect(mockApi.addCourt).not.toBeCalled();
 
@@ -152,7 +154,8 @@ describe('NewCourtController', () => {
       'redirectUrl': '',
       'serviceAreaChecked': true,
       'allServiceAreas': getAllServiceAreas(),
-      'serviceAreas': []
+      'serviceAreas': [],
+      'fatalError': false,
     });
     expect(mockApi.addCourt).not.toBeCalled();
 
@@ -188,7 +191,8 @@ describe('NewCourtController', () => {
       'redirectUrl': '',
       'serviceAreaChecked': true,
       'allServiceAreas': getAllServiceAreas(),
-      'serviceAreas': ['one', 'two', 'three']
+      'serviceAreas': ['one', 'two', 'three'],
+      'fatalError': false,
     });
     expect(mockApi.addCourt).not.toBeCalled();
 
@@ -223,7 +227,8 @@ describe('NewCourtController', () => {
       'redirectUrl': '',
       'serviceAreaChecked': true,
       'allServiceAreas': getAllServiceAreas(),
-      'serviceAreas': ['one', 'two', 'three']
+      'serviceAreas': ['one', 'two', 'three'],
+      'fatalError': false,
     });
     expect(mockApi.addCourt).not.toBeCalled();
   });
@@ -258,7 +263,8 @@ describe('NewCourtController', () => {
       'redirectUrl': '',
       'serviceAreaChecked': true,
       'allServiceAreas': getAllServiceAreas(),
-      'serviceAreas': ['one', 'two', 'three']
+      'serviceAreas': ['one', 'two', 'three'],
+      'fatalError': false,
     });
     expect(mockApi.addCourt).not.toBeCalled();
   });
@@ -295,7 +301,8 @@ describe('NewCourtController', () => {
       'redirectUrl': '',
       'serviceAreaChecked': true,
       'allServiceAreas': getAllServiceAreas(),
-      'serviceAreas': ['one', 'two', 'three']
+      'serviceAreas': ['one', 'two', 'three'],
+      'fatalError': false,
     });
     expect(mockApi.addCourt).toBeCalledWith({'lat': '10', 'lon': '10',
       'new_court_name': 'mosh court', 'service_centre': true,
@@ -329,7 +336,8 @@ describe('NewCourtController', () => {
       'redirectUrl': '/courts/mosh-court/edit#general',
       'serviceAreaChecked': true,
       'allServiceAreas': getAllServiceAreas(),
-      'serviceAreas': ['one', 'two', 'three']
+      'serviceAreas': ['one', 'two', 'three'],
+      'fatalError': false,
     });
     expect(mockApi.addCourt).toBeCalledWith({'lat': '10', 'lon': '10',
       'new_court_name': 'mosh court', 'service_centre': true,

--- a/src/test/unit/app/controller/courts/OpeningTimesController.ts
+++ b/src/test/unit/app/controller/courts/OpeningTimesController.ts
@@ -9,9 +9,9 @@ import {CSRF} from '../../../../../main/modules/csrf';
 describe('OpeningTimesController', () => {
 
   let mockApi: {
-    getOpeningTimes: () => Promise<OpeningTime[]>,
-    updateOpeningTimes: () => Promise<OpeningTime[]>,
-    getOpeningTimeTypes: () => Promise<OpeningType[]> };
+    getOpeningTimes: () => Promise<OpeningTime[]>;
+    updateOpeningTimes: () => Promise<OpeningTime[]>;
+    getOpeningTimeTypes: () => Promise<OpeningType[]>;};
 
   const getOpeningTimes: () => OpeningTime[] = () => [
     { 'type_id': 1, hours: '9am to 5pm', isNew: false },
@@ -67,7 +67,8 @@ describe('OpeningTimesController', () => {
       'opening_times': expectedOpeningTimes,
       openingTimeTypes: expectedSelectItems,
       updated: false,
-      errors: []
+      errors: [],
+      fatalError: false
     };
     expect(res.render).toBeCalledWith('courts/tabs/openingHoursContent', expectedResults);
   });
@@ -152,7 +153,8 @@ describe('OpeningTimesController', () => {
       'opening_times': postedOpeningTimes,
       openingTimeTypes: expectedSelectItems,
       updated: false,
-      errors: [{text: controller.updateErrorMsg}]
+      errors: [{text: controller.updateErrorMsg}],
+      fatalError: false
     };
 
     await controller.put(req, res);
@@ -177,7 +179,8 @@ describe('OpeningTimesController', () => {
       'opening_times': null,
       openingTimeTypes: expectedSelectItems,
       updated: false,
-      errors: [{text: controller.getOpeningTimesErrorMsg}]
+      errors: [{text: controller.getOpeningTimesErrorMsg}],
+      fatalError: true,
     };
     expect(res.render).toBeCalledWith('courts/tabs/openingHoursContent', expectedResults);
   });
@@ -200,7 +203,8 @@ describe('OpeningTimesController', () => {
       'opening_times': expectedOpeningTimes,
       openingTimeTypes: [],
       updated: false,
-      errors: [{text: controller.getOpeningTypesErrorMsg}]
+      errors: [{text: controller.getOpeningTypesErrorMsg}],
+      fatalError: true,
     };
     expect(res.render).toBeCalledWith('courts/tabs/openingHoursContent', expectedResults);
   });
@@ -223,7 +227,8 @@ describe('OpeningTimesController', () => {
       'opening_times': postedOpeningTimes,
       openingTimeTypes: expectedSelectItems,
       updated: false,
-      errors: [{text: controller.openingTimeDuplicatedErrorMsg}]
+      errors: [{text: controller.openingTimeDuplicatedErrorMsg}],
+      fatalError: false
     };
     expect(res.render).toBeCalledWith('courts/tabs/openingHoursContent', expectedResults);
   });
@@ -251,7 +256,8 @@ describe('OpeningTimesController', () => {
       errors: [
         {text: controller.emptyTypeOrHoursErrorMsg},
         {text: controller.openingTimeDuplicatedErrorMsg}
-      ]
+      ],
+      fatalError: false
     };
     expect(res.render).toBeCalledWith('courts/tabs/openingHoursContent', expectedResults);
   });

--- a/src/test/unit/app/controller/courts/PostcodeController.ts
+++ b/src/test/unit/app/controller/courts/PostcodeController.ts
@@ -9,13 +9,13 @@ import {CourtTypesAndCodes} from '../../../../../main/types/CourtTypesAndCodes';
 describe('PostcodeController', () => {
 
   let mockApi: {
-    getPostcodes: () => Promise<string[]>,
-    addPostcodes: () => Promise<string[]>,
-    getCourts: () => Promise<object[]>,
-    deletePostcodes: () => Promise<object>,
-    movePostcodes: () => Promise<object[]>,
-    getCourtAreasOfLaw: () => Promise<AreaOfLaw[]>,
-    getCourtTypesAndCodes: () => Promise<CourtTypesAndCodes>};
+    getPostcodes: () => Promise<string[]>;
+    addPostcodes: () => Promise<string[]>;
+    getCourts: () => Promise<object[]>;
+    deletePostcodes: () => Promise<object>;
+    movePostcodes: () => Promise<object[]>;
+    getCourtAreasOfLaw: () => Promise<AreaOfLaw[]>;
+    getCourtTypesAndCodes: () => Promise<CourtTypesAndCodes>;};
 
   const testSlug = 'plymouth-combined-court';
   const getPostcodeData = ['PL1', 'PL2', 'PL3', 'PL11 1YY', 'PL1 1', 'PL 1'];
@@ -127,7 +127,8 @@ describe('PostcodeController', () => {
       errors: [],
       isEnabled: true,
       areasOfLaw: areasOfLawMethodOutput,
-      courtTypes: courtTypesMethodOutput
+      courtTypes: courtTypesMethodOutput,
+      fatalError: false,
     });
     expect(mockApi.getCourtAreasOfLaw).toBeCalledWith(testSlug);
     expect(mockApi.getCourtTypesAndCodes).toBeCalledWith(testSlug);
@@ -153,7 +154,8 @@ describe('PostcodeController', () => {
       errors: [{text: controller.getCourtsErrorMsg}],
       isEnabled: true,
       areasOfLaw: areasOfLawMethodOutput,
-      courtTypes: courtTypesMethodOutput
+      courtTypes: courtTypesMethodOutput,
+      fatalError: false,
     });
     expect(mockApi.getCourtAreasOfLaw).toBeCalledWith(testSlug);
     expect(mockApi.getCourtTypesAndCodes).toBeCalledWith(testSlug);
@@ -186,7 +188,8 @@ describe('PostcodeController', () => {
       errors: [],
       isEnabled: false, // check this is false
       areasOfLaw: areasOfLawMethodOutput,
-      courtTypes: courtTypesMethodOutputInvalid
+      courtTypes: courtTypesMethodOutputInvalid,
+      fatalError: false,
     });
   });
 
@@ -215,7 +218,8 @@ describe('PostcodeController', () => {
       errors: [{text: controller.duplicatePostcodeMsg + 'PL3'}],
       isEnabled: true,
       areasOfLaw: areasOfLawMethodOutput,
-      courtTypes: courtTypesMethodOutput
+      courtTypes: courtTypesMethodOutput,
+      fatalError: false,
     });
     expect(mockApi.addPostcodes).not.toBeCalled();
     expect(mockApi.getCourtAreasOfLaw).not.toBeCalled();
@@ -247,7 +251,8 @@ describe('PostcodeController', () => {
       errors: [{text: controller.postcodesNotValidMsg + 'P,M,KUPOMOSH123'}],
       isEnabled: true,
       areasOfLaw: areasOfLawMethodOutput,
-      courtTypes: courtTypesMethodOutput
+      courtTypes: courtTypesMethodOutput,
+      fatalError: false,
     });
     expect(mockApi.addPostcodes).not.toBeCalled();
     expect(mockApi.getCourtAreasOfLaw).not.toBeCalled();
@@ -278,7 +283,8 @@ describe('PostcodeController', () => {
       errors: [],
       isEnabled: true,
       areasOfLaw: areasOfLawMethodOutput,
-      courtTypes: courtTypesMethodOutput
+      courtTypes: courtTypesMethodOutput,
+      fatalError: false,
     });
     expect(mockApi.addPostcodes).toBeCalledWith(testSlug, newPostcodes.split(','));
     expect(mockApi.getCourtAreasOfLaw).not.toBeCalled();
@@ -312,7 +318,8 @@ describe('PostcodeController', () => {
       errors: [{'text': 'A problem has occurred (your changes have not been saved). The following postcodes are invalid: pl1'}],
       isEnabled: true,
       areasOfLaw: areasOfLawMethodOutput,
-      courtTypes: courtTypesMethodOutput
+      courtTypes: courtTypesMethodOutput,
+      fatalError: false,
     });
     expect(mockApi.addPostcodes).toBeCalledWith(testSlug, newPostcodes.split(','));
     expect(mockApi.getCourtAreasOfLaw).not.toBeCalled();
@@ -345,7 +352,8 @@ describe('PostcodeController', () => {
       errors: [{text: controller.addErrorMsg}],
       isEnabled: true,
       areasOfLaw: areasOfLawMethodOutput,
-      courtTypes: courtTypesMethodOutput
+      courtTypes: courtTypesMethodOutput,
+      fatalError: false,
     });
     expect(mockApi.addPostcodes).not.toBeCalled();
     expect(mockApi.getCourtAreasOfLaw).not.toBeCalled();
@@ -377,7 +385,8 @@ describe('PostcodeController', () => {
       errors: [{text: controller.noPostcodeErrorMsg}],
       isEnabled: true,
       areasOfLaw: areasOfLawMethodOutput,
-      courtTypes: courtTypesMethodOutput
+      courtTypes: courtTypesMethodOutput,
+      fatalError: false,
     });
     expect(mockApi.addPostcodes).not.toBeCalled();
     expect(mockApi.getCourtAreasOfLaw).not.toBeCalled();
@@ -410,7 +419,8 @@ describe('PostcodeController', () => {
       errors: [{text: controller.addErrorMsg}],
       isEnabled: true,
       areasOfLaw: areasOfLawMethodOutput,
-      courtTypes: courtTypesMethodOutput
+      courtTypes: courtTypesMethodOutput,
+      fatalError: false,
     });
     expect(mockApi.deletePostcodes).not.toBeCalled();
     expect(mockApi.getCourtAreasOfLaw).not.toBeCalled();
@@ -442,7 +452,8 @@ describe('PostcodeController', () => {
       errors: [{text: controller.noSelectedPostcodeMsg}],
       isEnabled: true,
       areasOfLaw: areasOfLawMethodOutput,
-      courtTypes: courtTypesMethodOutput
+      courtTypes: courtTypesMethodOutput,
+      fatalError: false,
     });
     expect(mockApi.deletePostcodes).not.toBeCalled();
     expect(mockApi.getCourtAreasOfLaw).not.toBeCalled();
@@ -473,7 +484,8 @@ describe('PostcodeController', () => {
       errors: [],
       isEnabled: true,
       areasOfLaw: areasOfLawMethodOutput,
-      courtTypes: courtTypesMethodOutput
+      courtTypes: courtTypesMethodOutput,
+      fatalError: false,
     });
     expect(mockApi.deletePostcodes).toBeCalledWith(testSlug, getDeletedPostcodes);
     expect(mockApi.getCourtAreasOfLaw).not.toBeCalled();
@@ -507,7 +519,8 @@ describe('PostcodeController', () => {
       errors: [{'text': 'A problem has occurred when attempting to delete the following postcodes: PL1,PL2,PL3'}],
       isEnabled: true,
       areasOfLaw: areasOfLawMethodOutput,
-      courtTypes: courtTypesMethodOutput
+      courtTypes: courtTypesMethodOutput,
+      fatalError: false,
     });
     expect(mockApi.deletePostcodes).toBeCalledWith(testSlug, ['PL1','PL2','PL3']);
     expect(mockApi.getCourtAreasOfLaw).not.toBeCalled();
@@ -544,7 +557,8 @@ describe('PostcodeController', () => {
       errors: [{'text': controller.moveErrorMsg}],
       isEnabled: true,
       areasOfLaw: areasOfLawMethodOutput,
-      courtTypes: courtTypesMethodOutput
+      courtTypes: courtTypesMethodOutput,
+      fatalError: false,
     });
     expect(mockApi.movePostcodes).not.toBeCalled();
     expect(mockApi.getCourtAreasOfLaw).not.toBeCalled();
@@ -577,7 +591,8 @@ describe('PostcodeController', () => {
       errors: [],
       isEnabled: true,
       areasOfLaw: areasOfLawMethodOutput,
-      courtTypes: courtTypesMethodOutput
+      courtTypes: courtTypesMethodOutput,
+      fatalError: false,
     });
     expect(mockApi.movePostcodes).toBeCalledWith(testSlug, 'Mosh Land Court', ['PL11 1YY','PL1 1']);
     expect(mockApi.getCourtAreasOfLaw).not.toBeCalled();
@@ -609,7 +624,8 @@ describe('PostcodeController', () => {
       errors: [{text: controller.noSelectedPostcodeOrCourtMsg}],
       isEnabled: true,
       areasOfLaw: areasOfLawMethodOutput,
-      courtTypes: courtTypesMethodOutput
+      courtTypes: courtTypesMethodOutput,
+      fatalError: false,
     });
     expect(mockApi.movePostcodes).not.toBeCalled();
     expect(mockApi.getCourtAreasOfLaw).not.toBeCalled();
@@ -644,7 +660,8 @@ describe('PostcodeController', () => {
       errors: [{'text': 'A problem has occurred when attempting to move the following postcodes: PL11 1YY,PL1 1'}],
       isEnabled: true,
       areasOfLaw: areasOfLawMethodOutput,
-      courtTypes: courtTypesMethodOutput
+      courtTypes: courtTypesMethodOutput,
+      fatalError: false,
     });
     expect(mockApi.movePostcodes).toBeCalledWith(testSlug, 'Mosh Land Court', ['PL11 1YY','PL1 1']);
     expect(mockApi.getCourtAreasOfLaw).not.toBeCalled();
@@ -681,7 +698,8 @@ describe('PostcodeController', () => {
           'court (your changes have not been saved): PL11 1YY,PL1 1'}],
       isEnabled: true,
       areasOfLaw: areasOfLawMethodOutput,
-      courtTypes: courtTypesMethodOutput
+      courtTypes: courtTypesMethodOutput,
+      fatalError: false,
     });
     expect(mockApi.movePostcodes).toBeCalledWith(testSlug, 'Mosh Land Court', ['PL11 1YY','PL1 1']);
     expect(mockApi.getCourtAreasOfLaw).not.toBeCalled();


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/FACT-961



adding disabled save buttons on all tabs  when service is down


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
