### PR TITLE
FACT-1263 fixed bug for removing new lines from validation rule

### DIFF
--- a/src/main/utils/validation.ts
+++ b/src/main/utils/validation.ts
@@ -81,7 +81,7 @@ export function postcodeIsValidFormat(postcode: string): boolean {
 export function replaceMultipleSpaces(data: any): void {
   const dataType = typeof data;
   const nbspRegex = /&nbsp;/gm;
-  const spaceRegex = /\s+/gm;
+  const spaceRegex = / +/gm;
   if (dataType == 'object')
   {
     Object.entries(data).forEach(([k, v]) => data[k] =

--- a/src/main/utils/validation.ts
+++ b/src/main/utils/validation.ts
@@ -78,10 +78,14 @@ export function postcodeIsValidFormat(postcode: string): boolean {
   return match?.length === 1 && match[0] === postcode;
 }
 
-export function replaceMultipleSpaces(data: any): void {
+export function replaceMultipleSpaces(data: any): any {
   const dataType = typeof data;
   const nbspRegex = /&nbsp;/gm;
   const spaceRegex = / +/gm;
+  if (dataType == 'string') {
+    data = data.replace(nbspRegex, '').replace(spaceRegex, ' ').trim();
+    return data;
+  }
   if (dataType == 'object')
   {
     Object.entries(data).forEach(([k, v]) => data[k] =

--- a/src/test/unit/app/utils/validation.ts
+++ b/src/test/unit/app/utils/validation.ts
@@ -74,4 +74,14 @@ describe('validation', () => {
       expect(invalidParameters).toEqual(validParameters);
     });
   });
+
+  describe('Removing multiple spaces should keep new lines', () => {
+    const badAddress = 'line 1\nline 2\nline      3';
+    const fixedAddress = replaceMultipleSpaces(badAddress);
+    const validAddress = 'line 1\nline 2\nline 3';
+    it('Should return string without multiple spaces', async () => {
+      expect(fixedAddress).toMatch(validAddress);
+    });
+  });
+
 });


### PR DESCRIPTION
### JIRA link ###
https://tools.hmcts.net/jira/browse/FACT-1263


### Change description ###
when adding addresses and finding validation issues or saving the entire address is moving to one line. this is now resolved but it will still remove multiple spaces as intended


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x ] No
```
