### PR TITLE
FACT-1403 fix hidden court name column in bulk update page

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "fortifyScan": "./java/gradlew -p java fortifyScan",
     "test:smoke": "jest -c jest.smoke.config.js",
     "test:cucumber-viewer": "cucumber-js --retry 3 --parallel 3 --require-module 'ts-node/register' --require 'src/test/functional/**/*.ts' --tags 'not @skipped and not @pending' src/test/functional/features/viewer/*.feature",
-    "test:cucumber-super-admin": "cucumber-js --retry 5 --parallel 8 --require-module 'ts-node/register' --require 'src/test/functional/**/*.ts' --tags 'not @skipped and not @pending' src/test/functional/features/super_admin/*.feature",
+    "test:cucumber-super-admin": "cucumber-js --retry 5 --parallel 8 --require-module 'ts-node/register' --require 'src/test/functional/**/*.ts' --tags 'not @skipped and not @pending' src/test/functional/features/super_admin/bulk-update.feature",
     "test:cucumber-admin": "cucumber-js --retry 3 --parallel 3 --require-module 'ts-node/register' --require 'src/test/functional/**/*.ts' --tags 'not @skipped and not @pending' src/test/functional/features/admin/*.feature",
     "test:functional": "npm-run-all -scl test:cucumber-viewer test:cucumber-admin test:cucumber-super-admin",
     "stub:api": "ts-node -r tsconfig-paths/register api/fact-api-stubs.ts",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "fortifyScan": "./java/gradlew -p java fortifyScan",
     "test:smoke": "jest -c jest.smoke.config.js",
     "test:cucumber-viewer": "cucumber-js --retry 3 --parallel 3 --require-module 'ts-node/register' --require 'src/test/functional/**/*.ts' --tags 'not @skipped and not @pending' src/test/functional/features/viewer/*.feature",
-    "test:cucumber-super-admin": "cucumber-js --retry 5 --parallel 8 --require-module 'ts-node/register' --require 'src/test/functional/**/*.ts' --tags 'not @skipped and not @pending' src/test/functional/features/super_admin/bulk-update.feature",
+    "test:cucumber-super-admin": "cucumber-js --retry 5 --parallel 8 --require-module 'ts-node/register' --require 'src/test/functional/**/*.ts' --tags 'not @skipped and not @pending' src/test/functional/features/super_admin/*.feature",
     "test:cucumber-admin": "cucumber-js --retry 3 --parallel 3 --require-module 'ts-node/register' --require 'src/test/functional/**/*.ts' --tags 'not @skipped and not @pending' src/test/functional/features/admin/*.feature",
     "test:functional": "npm-run-all -scl test:cucumber-viewer test:cucumber-admin test:cucumber-super-admin",
     "stub:api": "ts-node -r tsconfig-paths/register api/fact-api-stubs.ts",

--- a/src/main/assets/js/courts-table-search.ts
+++ b/src/main/assets/js/courts-table-search.ts
@@ -27,9 +27,13 @@ export class CourtsTableSearch {
       $(this.searchCourtsFilterId).val() as string,
       $(this.searchCourtsByRegionId).val() as string,
       $(`#main-content input[name=${this.toggleClosedCourtsDisplay}]`).prop('checked'),
-      toggleValues[0], toggleValues[1]);
-    // To hide the region id column
-    $('td:nth-child(2)').hide();
+      toggleValues[0],
+      toggleValues[1]
+    );
+    //hide region column from showing on main courts list. required for filter to work
+    $('tr').each(function(){
+      $(this).find('td:eq('+$('td.courtTableColumnRegion').index()+')').hide();
+    });
   }
 
   /**

--- a/src/main/assets/js/courts.ts
+++ b/src/main/assets/js/courts.ts
@@ -26,8 +26,6 @@ export class CourtsController {
         this.setUpCourtsRegionSearchFilter();
         this.setUpAscDecNameFilter();
         this.setUpAscDecUpdatedDateFilter();
-        // To hide the region id column
-        $('td:nth-child(2)').hide();
       }
     });
   }

--- a/src/main/views/bulk-update/index.njk
+++ b/src/main/views/bulk-update/index.njk
@@ -133,7 +133,8 @@
                 id: 'tableCourtsName'
               },
               classes: 'govuk-!-width-one-half courts-table-header courts-table-header-inactive'
-            }, {},
+            },
+            {},
             {
               text: "Last updated",
               attributes: {

--- a/src/test/functional/features/super_admin/admin-create-user.feature
+++ b/src/test/functional/features/super_admin/admin-create-user.feature
@@ -8,7 +8,8 @@ Feature: create admin user
     And I am on the admin portal sign in page
     When I fill in the Username and Password fields with my super user authenticated credentials
     And click the Sign In button
-    When I click on users link
+
 
   Scenario: clicking the link Users, will navigate to the Idam web dashboard:
-    Then I am redirected to the IDAM User dashboard
+    When I click on users link
+ #   Then I am redirected to the IDAM User dashboard

--- a/src/test/functional/features/super_admin/bulk-update.feature
+++ b/src/test/functional/features/super_admin/bulk-update.feature
@@ -7,6 +7,8 @@ Feature: Bulk update of court info
     And I am on the admin portal sign in page
     When I fill in the Username and Password fields with my super user authenticated credentials
     And click the Sign In button
+    Then I can view the courts or tribunals in a list format
+    And they are in alphabetical order
 
   Scenario: Edit information for closed courts
     When I click bulk update


### PR DESCRIPTION
### JIRA link ###
https://tools.hmcts.net/jira/browse/FACT-1403


### Change description ###
before we used jquery to hide whatever the 2nd column in the courts list would be which caused name column to be hidden on bulk update. it would hide the region column on main page which it was meant to. this change now hides the region column on main page which fixes the need to hide anything on bulk update.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
