### PR TITLE
CVE-2023-45819 - Bumped tinyMCE version

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "sanitize-html": "^2.7.2",
     "serve-favicon": "^2.5.0",
     "session-file-store": "^1.5.0",
-    "tinymce": "^5.10.7",
+    "tinymce": "^5.10.8",
     "ts-node": "^10.9.1",
     "tsconfig-paths": "^4.2.0",
     "typescript": "^4.7.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6633,7 +6633,7 @@ __metadata:
     sinon-chai: ^3.7.0
     sonar-scanner: ^3.1.0
     style-loader: ^3.3.1
-    tinymce: ^5.10.7
+    tinymce: ^5.10.8
     ts-jest: ^28.0.7
     ts-loader: ^9.3.1
     ts-node: ^10.9.1
@@ -12662,10 +12662,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tinymce@npm:^5.10.7":
-  version: 5.10.7
-  resolution: "tinymce@npm:5.10.7"
-  checksum: fe471f1004a29523d5ac39fc5023c2aa30efee653366dfd1c3c6649be2178bd04f87985c9cec00662465cd623a4f3572734ee1009c4edcf0f5af339dd7a544ad
+"tinymce@npm:^5.10.8":
+  version: 5.10.8
+  resolution: "tinymce@npm:5.10.8"
+  checksum: 702f4f576ecd64087ee588c79f66d859dac8c3d6e9f671016dc41885fcb8c30a637a169eb67195ee2bb0eb1368759801ec191b2325a3bb341d32da1a88f5b680
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Change description ###

- Bumped tinyMCE to 5.10.8 to patch [CVE-2023-45819](https://github.com/advisories/GHSA-hgqx-r2hp-jr38)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
