### PR TITLE
FACT Admin 1493 - Headings and Labels

### DIFF
--- a/src/main/views/bulk-update/index.njk
+++ b/src/main/views/bulk-update/index.njk
@@ -13,9 +13,9 @@
   <h1 class="govuk-heading-xl">Bulk edit of additional information</h1>
   {% if updated %}
     <div class="govuk-panel govuk-panel--confirmation" id="updated-message">
-      <h1 class="govuk-panel__title">
+      <h2 class="govuk-panel__title">
         Court information updated
-      </h1>
+      </h2>
     </div>
   {% elif error %}
     {{ govukErrorSummary({
@@ -32,18 +32,18 @@
   <form method="POST">
 
     <div class="govuk-form-group">
-      <h1 class="govuk-label-wrapper"><label class="govuk-label govuk-label--m" for="info_message">
+      <h2 class="govuk-label-wrapper"><label class="govuk-label govuk-label--m" for="info_message">
         Additional information
       </label>
-      </h1>
+      </h2>
       <textarea class="govuk-textarea rich-editor" id="info_message" name="info" rows="3">{{ court['info'] }}</textarea>
     </div>
 
     <div class="govuk-form-group">
-      <h1 class="govuk-label-wrapper"><label class="govuk-label govuk-label--m" for="info_message_cy">
+      <h2 class="govuk-label-wrapper"><label class="govuk-label govuk-label--m" for="info_message_cy">
         Additional information (Welsh)
       </label>
-      </h1>
+      </h2>
       <textarea class="govuk-textarea rich-editor" id="info_message_cy" name="info_cy" rows="3">{{ court['info_cy'] }}</textarea>
     </div>
 

--- a/src/main/views/courts/addNewCourt.njk
+++ b/src/main/views/courts/addNewCourt.njk
@@ -108,7 +108,7 @@
       fieldset: {
         legend: {
           text: "Service Centre",
-          isPageHeading: true,
+          isPageHeading: false,
           classes: "govuk-fieldset__legend--m"
         }
       },
@@ -147,9 +147,9 @@
       <div id="serviceAreasContainer">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
 
-        <h1 class="govuk-fieldset__heading">
+        <h2 class="govuk-fieldset__heading">
           Service Areas
-        </h1>
+        </h2>
         </legend>
 
         <div id="serviceCentre-hint" class="govuk-hint">

--- a/src/main/views/lists/tabs/localAuthoritiesListContent.njk
+++ b/src/main/views/lists/tabs/localAuthoritiesListContent.njk
@@ -66,7 +66,7 @@
       label: {
         text: "Edit " + selected.name,
         classes: "govuk-label--m",
-        isPageHeading: true,
+        isPageHeading: false,
         attributes :  { "id": "selected" }
       },
       id: "local-authority",


### PR DESCRIPTION
### JIRA link ###
https://tools.hmcts.net/jira/browse/FACT-1493


### Change description ###

- Each page should now only have the top heading as an h1 tag
- In elements, e.g. Service Centre, where Nunjucks was used to create the h1 tag, the field `isPageHeading` was set to false. However, this means that the element is not a header in any way now i.e. not an h2, h3. So it does not show up in the structure. 
- Although It feels like Service Centre and editing a specific Local Authority should still be some type of header (e.g. h3) in the structure for accessibility. I can't see that it is [possible](https://design-system.service.gov.uk/get-started/labels-legends-headings/) to do with this specific nunjucks component

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
