### PR TITLE
FACT-2203 - More Descriptive Page Titles

### DIFF
--- a/src/main/modules/nunjucks/index.ts
+++ b/src/main/modules/nunjucks/index.ts
@@ -4,6 +4,7 @@ import * as nunjucks from 'nunjucks';
 import {SelectItem} from '../../types/CourtPageData';
 import {CSRF} from '../csrf';
 import config from 'config';
+import createFilters from './njkFilters';
 
 export class Nunjucks {
   constructor(public developmentMode: boolean) {
@@ -37,6 +38,8 @@ export class Nunjucks {
       return (!(regExp.test(string) || isNaN(string)) );
 
     });
+
+    createFilters(env);
 
     env.addGlobal('factFrontendURL', config.get('services.frontend.url'));
 

--- a/src/main/modules/nunjucks/index.ts
+++ b/src/main/modules/nunjucks/index.ts
@@ -24,21 +24,6 @@ export class Nunjucks {
 
     env.addFilter('selectFilter', this.selectFilter);
 
-    env.addFilter('setAttribute', function(dictionary , key , value){
-      dictionary[key] = value;
-      return dictionary;
-    });
-
-    env.addFilter('is_not_a_number', function(obj) {
-      return isNaN(obj);
-    });
-
-    env.addFilter('valid', function(string){
-      const regExp = /[a-zA-Z]/g;
-      return (!(regExp.test(string) || isNaN(string)) );
-
-    });
-
     createFilters(env);
 
     env.addGlobal('factFrontendURL', config.get('services.frontend.url'));

--- a/src/main/modules/nunjucks/index.ts
+++ b/src/main/modules/nunjucks/index.ts
@@ -1,7 +1,6 @@
 import * as path from 'path';
 import * as express from 'express';
 import * as nunjucks from 'nunjucks';
-import {SelectItem} from '../../types/CourtPageData';
 import {CSRF} from '../csrf';
 import config from 'config';
 import createFilters from './njkFilters';
@@ -22,7 +21,6 @@ export class Nunjucks {
       },
     );
 
-    env.addFilter('selectFilter', this.selectFilter);
 
     createFilters(env);
 
@@ -34,28 +32,6 @@ export class Nunjucks {
       res.locals.pagePath = req.path;
       next();
     });
-  }
-
-
-  private selectFilter(arr: SelectItem[], selectedId: string) {
-    // Set selected property on selected item
-    let itemSelected = false;
-    arr.forEach(si => {
-      if (si.value?.toString() === selectedId?.toString()) {
-        si.selected = true;
-        itemSelected = true;
-      } else {
-        si.selected = false;
-      }
-    });
-
-    // If we don't have a selected item, add an empty item and select this.
-    // This means the select control will show an empty value if there is no selection or
-    // if the selected item doesn't exist in the array of items in the select.
-    if (!itemSelected) {
-      arr.splice(0, 0, {value: '', text: '', selected: true});
-    }
-    return arr;
   }
 
 }

--- a/src/main/modules/nunjucks/njkFilters.ts
+++ b/src/main/modules/nunjucks/njkFilters.ts
@@ -4,7 +4,9 @@ const DEPARTMENT_SERVICE = 'Find a Court or Tribunal Admin Service – GOV.UK';
 const DASH = '-';
 
 function createFilters(env: nunjucks.Environment): void {
-  // make a title more descriptive using the route
+  // Takes a string or an array of strings and joins them together with dashes.
+  // Also appends information about the service. To be used in nunjucks filters to make titles more descriptive
+  // Note: If an empty list or string is given as an input then the department/service will be returned.
   env.addFilter('titleEnhancer', function (titleParts: string | string[]) {
     if (typeof titleParts === 'string') {
 

--- a/src/main/modules/nunjucks/njkFilters.ts
+++ b/src/main/modules/nunjucks/njkFilters.ts
@@ -29,6 +29,21 @@ function createFilters(env: nunjucks.Environment): void {
       return trimmedParts.join(' ' + DASH + ' ') ;
     }
   });
+
+  env.addFilter('setAttribute', function(dictionary , key , value){
+    dictionary[key] = value;
+    return dictionary;
+  });
+
+  env.addFilter('is_not_a_number', function(obj) {
+    return isNaN(obj);
+  });
+
+  env.addFilter('valid', function(string){
+    const regExp = /[a-zA-Z]/g;
+    return (!(regExp.test(string) || isNaN(string)) );
+
+  });
 }
 
 export default createFilters;

--- a/src/main/modules/nunjucks/njkFilters.ts
+++ b/src/main/modules/nunjucks/njkFilters.ts
@@ -1,4 +1,5 @@
 import nunjucks from 'nunjucks';
+import {SelectItem} from '../../types/CourtPageData';
 
 const DEPARTMENT_SERVICE = 'Find a Court or Tribunal Admin Service – GOV.UK';
 const DASH = '-';
@@ -44,6 +45,29 @@ function createFilters(env: nunjucks.Environment): void {
     return (!(regExp.test(string) || isNaN(string)) );
 
   });
+
+  env.addFilter('selectFilter', selectFilter);
+}
+
+function selectFilter(arr: SelectItem[], selectedId: string) {
+  // Set selected property on selected item
+  let itemSelected = false;
+  arr.forEach(si => {
+    if (si.value?.toString() === selectedId?.toString()) {
+      si.selected = true;
+      itemSelected = true;
+    } else {
+      si.selected = false;
+    }
+  });
+
+  // If we don't have a selected item, add an empty item and select this.
+  // This means the select control will show an empty value if there is no selection or
+  // if the selected item doesn't exist in the array of items in the select.
+  if (!itemSelected) {
+    arr.splice(0, 0, {value: '', text: '', selected: true});
+  }
+  return arr;
 }
 
 export default createFilters;

--- a/src/main/modules/nunjucks/njkFilters.ts
+++ b/src/main/modules/nunjucks/njkFilters.ts
@@ -1,0 +1,32 @@
+import nunjucks from 'nunjucks';
+
+const DEPARTMENT_SERVICE = 'Find a Court or Tribunal Admin Service – GOV.UK';
+const DASH = '-';
+
+function createFilters(env: nunjucks.Environment): void {
+  // make a title more descriptive using the route
+  env.addFilter('titleEnhancer', function (titleParts: string | string[]) {
+    if (typeof titleParts === 'string') {
+
+      const trimmedPart = titleParts.trim();
+
+      if(trimmedPart.length === 0) {
+        return DEPARTMENT_SERVICE;
+      } else {
+        return trimmedPart + ' ' + DASH + ' ' + DEPARTMENT_SERVICE;
+      }
+    } else if (Array.isArray(titleParts)) {
+      const trimmedParts = titleParts.map((part) => {
+        if (typeof part === 'string') {
+          return part.trim();
+        } else {
+          return '';
+        }
+      }).filter(part => part !== '');
+      trimmedParts.push(DEPARTMENT_SERVICE);
+      return trimmedParts.join(' ' + DASH + ' ') ;
+    }
+  });
+}
+
+export default createFilters;

--- a/src/main/modules/nunjucks/njkFilters.ts
+++ b/src/main/modules/nunjucks/njkFilters.ts
@@ -5,10 +5,10 @@ const DEPARTMENT_SERVICE = 'Find a Court or Tribunal Admin Service – GOV.UK';
 const DASH = '-';
 
 function createFilters(env: nunjucks.Environment): void {
-  // Takes a string or an array of strings and joins them together with dashes.
-  // Also appends information about the service. To be used in nunjucks filters to make titles more descriptive
-  // Note: If an empty list or string is given as an input then the department/service will be returned.
   env.addFilter('titleEnhancer', function (titleParts: string | string[]) {
+    // Takes a string or an array of strings and joins them together with dashes.
+    // Also appends information about the service. To be used in nunjucks templates to make titles more descriptive
+    // Note: If an empty list or string is given as an input then the department/service will be returned.
     if (typeof titleParts === 'string') {
 
       const trimmedPart = titleParts.trim();

--- a/src/main/views/audits/index.njk
+++ b/src/main/views/audits/index.njk
@@ -1,5 +1,5 @@
 {% extends "template.njk" %}
-{% block pageTitle %}Audits{% endblock %}
+{% block pageTitle %}{{ 'Audits' | titleEnhancer }}{% endblock %}
 {% block content %}
 <form id="auditsSearchForm" method="GET" class='govuk-grid-row'>
   <div id = 'auditsPageContent'></div>

--- a/src/main/views/bulk-update/index.njk
+++ b/src/main/views/bulk-update/index.njk
@@ -8,7 +8,7 @@
 
 
 {% extends "template.njk" %}
-{% block pageTitle %}Bulk edit of additional information{% endblock %}
+{% block pageTitle %}{{ 'Bulk edit of additional information' | titleEnhancer}}{% endblock %}
 
 
 {% block content %}

--- a/src/main/views/courts/addNewCourt.njk
+++ b/src/main/views/courts/addNewCourt.njk
@@ -8,7 +8,7 @@
 {% from "macros/csrf.njk" import csrfProtection %}
 
 {% extends "template.njk" %}
-{% block pageTitle %}Add new court{% endblock %}
+{% block pageTitle %}{{ 'Add new court' | titleEnhancer }}{% endblock %}
 
 {% block content %}
   {% if created === true %}
@@ -156,7 +156,7 @@
             {% set serviceAreaErrorDesc = formErrors.serviceAreaError.text %}
             <div class="govuk-form-group govuk-form-group--error">
               {{ govukErrorMessage({
-                  text: serviceAreaErrorDesc}) 
+                  text: serviceAreaErrorDesc})
               }}
           {% else %}
             <div class="govuk-form-group">
@@ -164,15 +164,15 @@
               {% for items in allServiceAreasItems|sort(false, true, 'text') | slice(2) %}
                 <div class="govuk-grid-column-one-half">
                   <div class="govuk-checkboxes" data-module="govuk-checkboxes">
-                    {% for item in items %}       
+                    {% for item in items %}
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" data-inputType="cases-heard" aria-checked={{ item.checked }} data-id 
+                          <input class="govuk-checkboxes__input" data-inputType="cases-heard" aria-checked={{ item.checked }} data-id
                            id="cases-heard-checkbox-{{ index.id }}" name="serviceAreaItems" type="checkbox" value='{{ item.value }}' {{ "checked" if item.checked }}>
                           <label class="govuk-label govuk-checkboxes__label" for="serviceAreaItems">
                             {{ item.text }}
                           </label>
-                        </div>                     
-                    {% endfor %}  
+                        </div>
+                    {% endfor %}
                   </div>
                 </div>
               {% endfor %}

--- a/src/main/views/courts/courts.njk
+++ b/src/main/views/courts/courts.njk
@@ -5,7 +5,7 @@
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
 {% extends "template.njk" %}
-{% block pageTitle %}Courts and tribunals{% endblock %}
+{% block pageTitle %}{{ 'Courts and tribunals' | titleEnhancer }}{% endblock %}
 {% block content %}
   <h1 class="govuk-heading-xl">Courts and tribunals</h1>
 

--- a/src/main/views/courts/edit-court-general.njk
+++ b/src/main/views/courts/edit-court-general.njk
@@ -6,7 +6,11 @@
 {% extends "template.njk" %}
 
 {% block pageTitle %}
-  {{['Edit Court', name ] | titleEnhancer}}
+  {% if isViewer %}
+    {{['Details', name ] | titleEnhancer}}
+   {% else %}
+    {{['Edit Court', name ] | titleEnhancer}}
+   {% endif %}
 {% endblock %}
 
 {% block content %}

--- a/src/main/views/courts/edit-court-general.njk
+++ b/src/main/views/courts/edit-court-general.njk
@@ -6,7 +6,7 @@
 {% extends "template.njk" %}
 
 {% block pageTitle %}
-  Edit Court
+  {{['Edit Court', name ] | titleEnhancer}}
 {% endblock %}
 
 {% block content %}

--- a/src/main/views/error.njk
+++ b/src/main/views/error.njk
@@ -1,5 +1,7 @@
 {% extends "template.njk" %}
-{% block pageTitle %}Something went wrong{% endblock %}
+{% block pageTitle %}
+  {{ 'Something went wrong' | titleEnhancer }}
+{% endblock %}
 {% block content %}
   <h1 class="govuk-heading-xl">Something went wrong</h1>
 {% endblock %}

--- a/src/main/views/lists/index.njk
+++ b/src/main/views/lists/index.njk
@@ -2,7 +2,7 @@
 {% from "macros/tabs/macro.njk" import factTabs %}
 
 {% extends "template.njk" %}
-{% block pageTitle %}Edit A List{% endblock %}
+{% block pageTitle %}{{ 'Edit A List' | titleEnhancer }}{% endblock %}
 {% block content %}
 
   <h1 class="govuk-heading-xl">Edit A List</h1>

--- a/src/main/views/not-found.njk
+++ b/src/main/views/not-found.njk
@@ -1,5 +1,7 @@
 {% extends "template.njk" %}
-{% block pageTitle %}Page Not Found{% endblock %}
+{% block pageTitle %}
+  {{ 'Page Not Found' | titleEnhancer }}
+{% endblock %}
 {% block content %}
   <h1 class="govuk-heading-xl">Page Not Found</h1>
 {% endblock %}

--- a/src/test/functional/features/admin/application-progression.feature
+++ b/src/test/functional/features/admin/application-progression.feature
@@ -9,7 +9,7 @@ Feature: Application Progression
     When I fill in the Username and Password fields with my super user authenticated credentials
     And click the Sign In button
     When I click edit next to court with "probate-service-centre"
-    Then I am redirected to the Edit Court page for the chosen court
+    Then I am redirected to the Edit Court page for the "Probate Service Centre"
     When I hover over nav element
     When I click the application progression tab
 

--- a/src/test/functional/features/admin/courts.feature
+++ b/src/test/functional/features/admin/courts.feature
@@ -10,7 +10,7 @@ Feature: Homepage
     When I select Include closed courts
 
   Scenario: View the list
-
+    When I am on the "Courts and tribunals" page
     Then I can view the courts or tribunals in a list format
     And they are in alphabetical order
 

--- a/src/test/functional/features/admin/general-info.feature
+++ b/src/test/functional/features/admin/general-info.feature
@@ -15,7 +15,7 @@ Feature: General Info
     And click the Sign In button
     When I select Include closed courts
     When I click edit next to court with "stafford-combined-court-centre"
-    Then I am redirected to the Edit Court page for the chosen court
+    Then I am redirected to the Edit Court page for the "Stafford Combined Court Centre"
     When I hover over general nav element
     When I click the general tab
     Then I can view the urgent notices

--- a/src/test/functional/features/admin/phone-numbers.feature
+++ b/src/test/functional/features/admin/phone-numbers.feature
@@ -8,7 +8,7 @@ Feature: Phone Numbers
     When I fill in the Username and Password fields with my authenticated credentials
     And click the Sign In button
     When I click edit next to court with "stafford-combined-court-centre"
-    Then I am redirected to the Edit Court page for the chosen court
+    Then I am redirected to the Edit Court page for the "Stafford Combined Court Centre"
     When I hover over phone numbers nav element
     When I click the phone numbers tab
     When I remove all existing phone number entries and save

--- a/src/test/functional/features/super_admin/additional-links.feature
+++ b/src/test/functional/features/super_admin/additional-links.feature
@@ -10,7 +10,7 @@ Feature: Additional-links
     When I fill in the Username and Password fields with my super user authenticated credentials
     And click the Sign In button
     When I click edit next to court with "aberystwyth-justice-centre"
-    Then I am redirected to the Edit Court page for the chosen court
+    Then I am redirected to the Edit Court page for the "Aberystwyth Justice Centre"
     When I hover over Additional Links nav element
     Then I click the Additional Links tab
     When I remove all existing Additional Links entries and save

--- a/src/test/functional/features/super_admin/admin-audit.feature
+++ b/src/test/functional/features/super_admin/admin-audit.feature
@@ -12,7 +12,7 @@ Feature: courts audits
 
   Scenario: view audits for super admin user
     When I click edit next to court with "havant-justice-centre"
-    Then I am redirected to the Edit Court page for the chosen court
+    Then I am redirected to the Edit Court page for the "Havant Justice Centre"
     When I hover over opening hours nav element
     When I click the opening hours tab
     Then I check action start time

--- a/src/test/functional/features/super_admin/admin-audit.feature
+++ b/src/test/functional/features/super_admin/admin-audit.feature
@@ -24,6 +24,7 @@ Feature: courts audits
     Then I check action end time
     Then I click on courts link
     When I click on audits link
+    Then I am on the "Audits" page
     Then I select "havant-justice-centre" from courts
     Then I enter between and end date
     Then I click search audit button

--- a/src/test/functional/features/super_admin/admin-court-addresses.feature
+++ b/src/test/functional/features/super_admin/admin-court-addresses.feature
@@ -9,7 +9,7 @@ Feature: Court-addresses
     When I fill in the Username and Password fields with my super user authenticated credentials
     And click the Sign In button
     When I click edit next to court with "barnsley-law-courts"
-    Then I am redirected to the Edit Court page for the chosen court
+    Then I am redirected to the Edit Court page for the "Barnsley Law Courts"
     And I hover over types nav element
     Then I click the Addresses tab
 #

--- a/src/test/functional/features/super_admin/cases-heard.feature
+++ b/src/test/functional/features/super_admin/cases-heard.feature
@@ -9,7 +9,7 @@ Feature: Cases-Heard tab
     When I fill in the Username and Password fields with my super user authenticated credentials
     And click the Sign In button
     When I click edit next to court with "basingstoke-county-court-and-family-court"
-    Then I am redirected to the Edit Court page for the chosen court
+    Then I am redirected to the Edit Court page for the "Basingstoke County Court and Family Court"
     When I hover over opening hours nav element
     When I click the cases heard tab
 

--- a/src/test/functional/features/super_admin/court-additional-information.feature
+++ b/src/test/functional/features/super_admin/court-additional-information.feature
@@ -11,7 +11,7 @@ Feature: Court Additional Information Message
 
   Scenario: Adding additional info English and Welsh
     When I click edit next to court with "birmingham-civil-and-family-justice-centre"
-    Then I am redirected to the Edit Court page for the chosen court
+    Then I am redirected to the Edit Court page for the "Birmingham Civil and Family Justice Centre"
     When I add an "Additional Information test" in the rich editor field provided "#info"
     When I add an "Welsh translation of the additional information test" in the rich editor field provided "#info_cy"
     And I click the general info save button

--- a/src/test/functional/features/super_admin/court-open-and-access-scheme.feature
+++ b/src/test/functional/features/super_admin/court-open-and-access-scheme.feature
@@ -12,7 +12,7 @@ Feature: Court Open and Access Scheme flags
   Scenario Outline: Open
 
     When I click edit next to court with "<view_court_slug>"
-    Then I am redirected to the Edit Court page for the chosen court
+    Then I am redirected to the Edit Court page for the "<view_court_name>"
     When I click the open checkbox
     And I click the general info save button
     Then a success message is displayed on the general info tab "General Information updated"
@@ -21,12 +21,12 @@ Feature: Court Open and Access Scheme flags
     Then a success message is displayed on the general info tab "General Information updated"
 
     Examples:
-      | view_court_slug                            |
-      | birmingham-district-probate-registry       |
+      | view_court_slug                            | view_court_name                      |
+      | birmingham-district-probate-registry       | Birmingham District Probate Registry |
 
   Scenario Outline: Access scheme
     When I click edit next to court with "<view_court_slug>"
-    Then I am redirected to the Edit Court page for the chosen court
+    Then I am redirected to the Edit Court page for the "<view_court_name>"
     When I click the Participates in access scheme checkbox
     And I click the general info save button
     Then a success message is displayed on the general info tab "General Information updated"
@@ -35,5 +35,5 @@ Feature: Court Open and Access Scheme flags
     Then a success message is displayed on the general info tab "General Information updated"
 
     Examples:
-      | view_court_slug                            |
-      | birmingham-district-probate-registry       |
+      | view_court_slug                            | view_court_name                      |
+      | birmingham-district-probate-registry       | Birmingham District Probate Registry |

--- a/src/test/functional/features/super_admin/court-photo.feature
+++ b/src/test/functional/features/super_admin/court-photo.feature
@@ -9,7 +9,7 @@ Feature: Update court photo
     When I fill in the Username and Password fields with my super user authenticated credentials
     And click the Sign In button
     When I click edit next to court with "aberdeen-tribunal-hearing-centre"
-    Then I am redirected to the Edit Court page for the chosen court
+    Then I am redirected to the Edit Court page for the "Aberdeen Tribunal Hearing Centre"
     When I hover over nav element
     When I click the photo tab
     Then I can view the existing court photo form

--- a/src/test/functional/features/super_admin/court-spoe.feature
+++ b/src/test/functional/features/super_admin/court-spoe.feature
@@ -10,7 +10,7 @@ Feature: Spoe tab
     When I fill in the Username and Password fields with my super user authenticated credentials
     And click the Sign In button
     When I click edit next to court with "cambridge-crown-court"
-    Then I am redirected to the Edit Court page for the chosen court
+    Then I am redirected to the Edit Court page for the "Cambridge Crown Court"
     When I hover over opening hours nav element
     When I click spoe tab
 

--- a/src/test/functional/features/super_admin/court-types.feature
+++ b/src/test/functional/features/super_admin/court-types.feature
@@ -9,7 +9,7 @@ Feature: Court Types
     When I fill in the Username and Password fields with my super user authenticated credentials
     And click the Sign In button
     When I click edit next to court with "basingstoke-county-court-and-family-court"
-    Then I am redirected to the Edit Court page for the chosen court
+    Then I am redirected to the Edit Court page for the "Basingstoke County Court and Family Court"
     When I hover over types nav element
     When I click the types tab
 

--- a/src/test/functional/features/super_admin/email-addresses.feature
+++ b/src/test/functional/features/super_admin/email-addresses.feature
@@ -9,7 +9,7 @@ Feature: Email-addresses
     When I fill in the Username and Password fields with my super user authenticated credentials
     And click the Sign In button
     When I click edit next to court with "barnet-civil-and-family-courts-centre"
-    Then I am redirected to the Edit Court page for the chosen court
+    Then I am redirected to the Edit Court page for the "Barnet Civil and Family Courts Centre"
     When I hover over emails nav element
     Then I click the Emails tab
 

--- a/src/test/functional/features/super_admin/facilities.feature
+++ b/src/test/functional/features/super_admin/facilities.feature
@@ -9,7 +9,7 @@ Feature: Facilities
     When I fill in the Username and Password fields with my super user authenticated credentials
     And click the Sign In button
     When I click edit next to court with "basingstoke-county-court-and-family-court"
-    Then I am redirected to the Edit Court page for the chosen court
+    Then I am redirected to the Edit Court page for the "Basingstoke County Court and Family Court"
     When I hover over opening hours nav element
     And I click the facilities tab
 

--- a/src/test/functional/features/super_admin/general-info.feature
+++ b/src/test/functional/features/super_admin/general-info.feature
@@ -12,7 +12,7 @@ Feature: General Info
     And click the Sign In button
     When I select Include closed courts
     When I click edit next to court with "amersham-law-courts"
-    Then I am redirected to the Edit Court page for the chosen court
+    Then I am redirected to the Edit Court page for the "Amersham Law Courts"
     When I hover over general nav element
     When I click the general tab
     Then I enter "" in the Name textbox
@@ -24,7 +24,7 @@ Feature: General Info
     And click the Sign In button
     When I select Include closed courts
     When I click edit next to court with "bankruptcy-court-high-court"
-    Then I am redirected to the Edit Court page for the chosen court
+    Then I am redirected to the Edit Court page for the "Bankruptcy Court (High Court)"
     When I hover over general nav element
     When I click the general tab
     Then I enter "Amersham Law Courts" in the Name textbox
@@ -36,7 +36,7 @@ Feature: General Info
     And click the Sign In button
     When I select Include closed courts
     When I click edit next to court with "north-west-regional-divorce-centre"
-    Then I am redirected to the Edit Court page for the chosen court
+    Then I am redirected to the Edit Court page for the "North West Regional Divorce Centre"
     When I hover over general nav element
     When I click the general tab
     When I add an "intro paragraph test" in the rich editor field provided "#sc_intro_paragraph"
@@ -49,7 +49,7 @@ Feature: General Info
     And click the Sign In button
     When I select Include closed courts
     When I click edit next to court with "amersham-law-courts"
-    Then I am redirected to the Edit Court page for the chosen court
+    Then I am redirected to the Edit Court page for the "Amersham Law Courts"
     When I hover over general nav element
     When I click the general tab
     Then I edit common platform checkbox

--- a/src/test/functional/features/super_admin/local-authorities.feature
+++ b/src/test/functional/features/super_admin/local-authorities.feature
@@ -13,7 +13,7 @@ Feature: Local authorities
   Scenario Outline: Local authorities updated successfully
 
     When I click edit next to court with "<view_court_slug>"
-    And I am redirected to the Edit Court page for the chosen court
+    And I am redirected to the Edit Court page for the "<view_court_name>"
     And I hover over types nav element
     And I click the types tab
     When I check code errors
@@ -27,13 +27,13 @@ Feature: Local authorities
     Then Success message is displayed for local authorities with summary "Local authorities updated"
 
     Examples:
-      | view_court_slug                            |
-      | birmingham-civil-and-family-justice-centre |
+      | view_court_slug                            | view_court_name                            |
+      | birmingham-civil-and-family-justice-centre | Birmingham Civil and Family Justice Centre |
 
   Scenario Outline: When there are no area of law selected for the chosen court user should get proper error message when he clicks on local authorities
 
     When I click edit next to court with "<view_court_slug>"
-    And I am redirected to the Edit Court page for the chosen court
+    And I am redirected to the Edit Court page for the "<view_court_name>"
     And I hover over types nav element
     And I click the types tab
     When I check code errors
@@ -48,13 +48,13 @@ Feature: Local authorities
     Then An error is displayed for local authorities with title "There is a problem" and summery "You need to enable relevant family court areas of law"
 
     Examples:
-      | view_court_slug      |
-      | administrative-court |
+      | view_court_slug      | view_court_name      |
+      | administrative-court | Administrative Court |
 
     Scenario Outline: When Family court type is not selected for the chosen court local authorities tab should be disabled for the user.
 
       When I click edit next to court with "<view_court_slug>"
-      Then I am redirected to the Edit Court page for the chosen court
+      Then I am redirected to the Edit Court page for the "<view_court_name>"
       And I hover over types nav element
       And I click the types tab
       When I check code errors
@@ -64,5 +64,5 @@ Feature: Local authorities
       Then The local authorities tab should be disabled
 
       Examples:
-        | view_court_slug          |
-        | administrative-court     |
+        | view_court_slug      | view_court_name      |
+        | administrative-court | Administrative Court |

--- a/src/test/functional/features/super_admin/opening-hours.feature
+++ b/src/test/functional/features/super_admin/opening-hours.feature
@@ -9,7 +9,7 @@ Feature: Opening Hours
     When I fill in the Username and Password fields with my super user authenticated credentials
     And click the Sign In button
     When I click edit next to court with "basingstoke-county-court-and-family-court"
-    Then I am redirected to the Edit Court page for the chosen court
+    Then I am redirected to the Edit Court page for the "Basingstoke County Court and Family Court"
     When I hover over opening hours nav element
     When I click the opening hours tab
     When I remove all existing opening hours entries and save

--- a/src/test/functional/features/super_admin/postcode-order.feature
+++ b/src/test/functional/features/super_admin/postcode-order.feature
@@ -10,7 +10,7 @@ Feature: Postcodes order
     And click the Sign In button
     When I select Include closed courts
     When I click edit next to court with "birmingham-civil-and-family-justice-centre"
-    Then I am redirected to the Edit Court page for the chosen court
+    Then I am redirected to the Edit Court page for the "Birmingham Civil and Family Justice Centre"
     And I hover over types nav element
     When I click the types tab
     And I will make sure County court type is selected

--- a/src/test/functional/features/super_admin/postcodes.feature
+++ b/src/test/functional/features/super_admin/postcodes.feature
@@ -10,7 +10,7 @@ Feature: Postcodes
     When I fill in the Username and Password fields with my super user authenticated credentials
     And click the Sign In button
     When I click edit next to court with "county-court-money-claims-centre-ccmcc"
-    Then I am redirected to the Edit Court page for the chosen court
+    Then I am redirected to the Edit Court page for the "County Court Money Claims Centre (CCMCC)"
     And I hover over types nav element
     When I click the types tab
     And I will make sure County court type is selected

--- a/src/test/functional/features/viewer/viewer-login.feature
+++ b/src/test/functional/features/viewer/viewer-login.feature
@@ -10,7 +10,7 @@ Feature: Login/Logout
     Then the system will sign me in
     And I cannot view super admin content
     When I click edit next to court with "bexley-magistrates-court"
-    Then I am redirected to the Edit Court page for the chosen court
+    Then I am redirected to the Details page for the "Bexley Magistrates' Court"
 
   Scenario Outline: viewer can log in and only see specific tabs for a selected court
     And It is "<shouldBeVisible>" that the "<tab>" tab is visible

--- a/src/test/functional/steps/admin-add-new-court.ts
+++ b/src/test/functional/steps/admin-add-new-court.ts
@@ -1,6 +1,7 @@
 import {Given, Then, When} from 'cucumber';
 import * as I from '../utlis/puppeteer.util';
 import {expect} from 'chai';
+import {FunctionalTestHelpers} from "../utlis/helpers";
 
 async function populateField(fieldElement: string, value: string) {
   expect(await I.checkElement(fieldElement)).equal(true);
@@ -18,6 +19,8 @@ Then('I am redirected to the add new court {string} page', async (addNewCourt: s
   const selector = '#addNewCourtForm > h1';
   const formTitle = await I.getElementText(await I.getElement(selector));
   expect(formTitle).equal(addNewCourt);
+  const pageTitle = await I.getPageTitle();
+  expect(pageTitle).equal(formTitle + ' - ' + FunctionalTestHelpers.DEPARTMENT_SERVICE);
 });
 
 Given('I entered the new court name as {string} in the name text box', async (name: string) => {

--- a/src/test/functional/steps/admin-add-new-court.ts
+++ b/src/test/functional/steps/admin-add-new-court.ts
@@ -1,7 +1,7 @@
 import {Given, Then, When} from 'cucumber';
 import * as I from '../utlis/puppeteer.util';
 import {expect} from 'chai';
-import {FunctionalTestHelpers} from "../utlis/helpers";
+import {FunctionalTestHelpers} from '../utlis/helpers';
 
 async function populateField(fieldElement: string, value: string) {
   expect(await I.checkElement(fieldElement)).equal(true);

--- a/src/test/functional/steps/bulk-update.ts
+++ b/src/test/functional/steps/bulk-update.ts
@@ -1,7 +1,7 @@
 import { Then, When } from 'cucumber';
 import * as I from '../utlis/puppeteer.util';
 import { expect } from 'chai';
-import {FunctionalTestHelpers} from "../utlis/helpers";
+import {FunctionalTestHelpers} from '../utlis/helpers';
 
 
 When('I click bulk update', async () => {

--- a/src/test/functional/steps/bulk-update.ts
+++ b/src/test/functional/steps/bulk-update.ts
@@ -1,6 +1,7 @@
 import { Then, When } from 'cucumber';
 import * as I from '../utlis/puppeteer.util';
 import { expect } from 'chai';
+import {FunctionalTestHelpers} from "../utlis/helpers";
 
 
 When('I click bulk update', async () => {
@@ -9,8 +10,10 @@ When('I click bulk update', async () => {
 
 Then('I am on the {string} page', async (title: string) => {
   const el = await I.getElement('h1');
-  const pageTitle = await I.getElementText(el);
-  expect(pageTitle).equal(title);
+  const pageHeading = await I.getElementText(el);
+  const pageTitle = await I.getPageTitle();
+  expect(pageHeading).equal(title);
+  expect(pageTitle).equal(title + ' - ' + FunctionalTestHelpers.DEPARTMENT_SERVICE);
 });
 
 When('I select court {string}', async (court: string) => {

--- a/src/test/functional/steps/courts.ts
+++ b/src/test/functional/steps/courts.ts
@@ -33,6 +33,19 @@ Then('I am redirected to the Edit Court page for the {string}', async (courtName
   await I.checkElementIsAnchor('#general');
 });
 
+Then('I am redirected to the Details page for the {string}', async (courtName: string) => {
+  const pageTitle = await I.getPageTitle();
+  const editCourtHeading = await I.getElement('#court-name');
+  const editCourtHeadingText = await I.getElementText(editCourtHeading);
+  expect(pageTitle).equal('Details - ' + courtName + ' - ' + FunctionalTestHelpers.DEPARTMENT_SERVICE);
+  expect(editCourtHeadingText).equal('Details - ' + courtName);
+  await I.checkElementIsAnchor('#courts');
+  await I.checkElementIsAnchor('#my-account');
+  await I.checkElementIsAnchor('#logout');
+  await I.checkElementIsAnchor('#view-in-new-window');
+  await I.checkElementIsAnchor('#general');
+});
+
 When('I click view next to court with {string}', async (courtSlug: string) => {
   const selector = '#view-' + courtSlug;
   const elementExist = await I.checkElement(selector);

--- a/src/test/functional/steps/courts.ts
+++ b/src/test/functional/steps/courts.ts
@@ -1,6 +1,7 @@
 import {Given, Then, When} from 'cucumber';
 import {expect} from 'chai';
 import * as I from '../utlis/puppeteer.util';
+import {FunctionalTestHelpers} from "../utlis/helpers";
 
 Then('I can view the courts or tribunals in a list format', async () => {
   const elementExist = await I.checkElement('#courts');
@@ -23,7 +24,7 @@ Then('I am redirected to the Edit Court page for the {string}', async (courtName
   const pageTitle = await I.getPageTitle();
   const editCourtHeading = await I.getElement('#court-name');
   const editCourtHeadingText = await I.getElementText(editCourtHeading);
-  expect(pageTitle).equal('Edit Court');
+  expect(pageTitle).equal('Edit Court - ' + courtName + ' - ' + FunctionalTestHelpers.DEPARTMENT_SERVICE);
   expect(editCourtHeadingText).equal('Editing - ' + courtName);
   await I.checkElementIsAnchor('#courts');
   await I.checkElementIsAnchor('#my-account');

--- a/src/test/functional/steps/courts.ts
+++ b/src/test/functional/steps/courts.ts
@@ -1,7 +1,7 @@
 import {Given, Then, When} from 'cucumber';
 import {expect} from 'chai';
 import * as I from '../utlis/puppeteer.util';
-import {FunctionalTestHelpers} from "../utlis/helpers";
+import {FunctionalTestHelpers} from '../utlis/helpers';
 
 Then('I can view the courts or tribunals in a list format', async () => {
   const elementExist = await I.checkElement('#courts');

--- a/src/test/functional/steps/courts.ts
+++ b/src/test/functional/steps/courts.ts
@@ -33,6 +33,7 @@ Then('I am redirected to the Edit Court page for the {string}', async (courtName
   await I.checkElementIsAnchor('#general');
 });
 
+// This step checks how the 'Edit Court' page should look for those with the viewer role.
 Then('I am redirected to the Details page for the {string}', async (courtName: string) => {
   const pageTitle = await I.getPageTitle();
   const editCourtHeading = await I.getElement('#court-name');

--- a/src/test/functional/steps/list-local-authorities.ts
+++ b/src/test/functional/steps/list-local-authorities.ts
@@ -12,8 +12,10 @@ When('I click on lists link', async () => {
 
 Then('I am redirected to the {string} page', async (editListTitle: string) => {
   const selector = '#main-content > h1';
-  const pageTitleElement = await I.getElement(selector);
-  expect(await I.getElementText(pageTitleElement)).equal(editListTitle);
+  const pageHeaderElement = await I.getElement(selector);
+  expect(await I.getElementText(pageHeaderElement)).equal(editListTitle);
+  const pageTitle = await I.getPageTitle();
+  expect(pageTitle).equal(editListTitle + ' - ' + FunctionalTestHelpers.DEPARTMENT_SERVICE);
 });
 
 When('I hover over the tab title', async () => {

--- a/src/test/functional/utlis/helpers.ts
+++ b/src/test/functional/utlis/helpers.ts
@@ -3,6 +3,8 @@ import {expect} from 'chai';
 
 export class FunctionalTestHelpers {
 
+  public static DEPARTMENT_SERVICE = 'Find a Court or Tribunal Admin Service – GOV.UK';
+
   public static async clickButtonAndCheckFieldsetAdded(containerId: string, buttonName: string, fieldsetClass = '') {
     const fieldsetSelector = `${containerId} fieldset${fieldsetClass}`;
     const numFieldsets = await I.countElement(fieldsetSelector);

--- a/src/test/unit/app/modules/nunjucks/njkFilters.ts
+++ b/src/test/unit/app/modules/nunjucks/njkFilters.ts
@@ -1,0 +1,68 @@
+import nunjucks from 'nunjucks';
+
+import createFilters from '../../../../../main/modules/nunjucks/njkFilters';
+
+describe('njkFilters', () => {
+  let env: nunjucks.Environment;
+
+  beforeEach(() => {
+    env = new nunjucks.Environment();
+    createFilters(env);
+  });
+
+  describe('Test the filter that creates web page titles (from a list of string)', () => {
+    test('should convert an array of strings into a descriptive title', () => {
+      const titleEnhanceFilter = env.getFilter('titleEnhancer');
+      const input = ['Editing', 'Aberystwyth Justice Centre'];
+      const expectedOutput
+        = 'Editing - Aberystwyth Justice Centre - Find a Court or Tribunal Admin Service – GOV.UK';
+
+      expect(titleEnhanceFilter(input)).toEqual(expectedOutput);
+    });
+
+    test('should not add empty strings to the title', () => {
+      const titleEnhanceFilter = env.getFilter('titleEnhancer');
+      const input = ['Editing', '', 'Aberystwyth Justice Centre', '  '];
+      const expectedOutput
+        = 'Editing - Aberystwyth Justice Centre - Find a Court or Tribunal Admin Service – GOV.UK';
+
+      expect(titleEnhanceFilter(input)).toEqual(expectedOutput);
+    });
+
+    test.each([[[]], [['  ', '']], [['']], [['  ']], [['', '  ', '']]])(`should just return department and service when array is ${JSON.stringify('%j')}`, (testCase: string[]) => {
+      const titleEnhanceFilter = env.getFilter('titleEnhancer');
+      const expectedOutput
+        = 'Find a Court or Tribunal Admin Service – GOV.UK';
+
+      expect(titleEnhanceFilter(testCase)).toEqual(expectedOutput);
+    });
+  });
+
+  describe('Test the filter that creates web page titles (from a string)', () => {
+    test('should convert an array of strings into a descriptive title', () => {
+      const titleEnhanceFilter = env.getFilter('titleEnhancer');
+      const input = 'Bulk Edit';
+      const expectedOutput
+        = 'Bulk Edit - Find a Court or Tribunal Admin Service – GOV.UK';
+
+      expect(titleEnhanceFilter(input)).toEqual(expectedOutput);
+    });
+
+    test('should not add empty strings to the title', () => {
+      const titleEnhanceFilter = env.getFilter('titleEnhancer');
+      const input = '';
+      const expectedOutput
+        = 'Find a Court or Tribunal Admin Service – GOV.UK';
+
+      expect(titleEnhanceFilter(input)).toEqual(expectedOutput);
+    });
+
+    test.each(['', '  '])('should not add empty strings such as %j to the title', (testCase) => {
+      const titleEnhanceFilter = env.getFilter('titleEnhancer');
+      const expectedOutput
+        = 'Find a Court or Tribunal Admin Service – GOV.UK';
+
+      expect(titleEnhanceFilter(testCase)).toEqual(expectedOutput);
+    });
+  });
+});

--- a/src/test/unit/app/modules/nunjucks/njkFilters.ts
+++ b/src/test/unit/app/modules/nunjucks/njkFilters.ts
@@ -39,7 +39,7 @@ describe('njkFilters', () => {
   });
 
   describe('Test the filter that creates web page titles (from a string)', () => {
-    test('should convert an array of strings into a descriptive title', () => {
+    test('should convert a string into a descriptive title', () => {
       const titleEnhanceFilter = env.getFilter('titleEnhancer');
       const input = 'Bulk Edit';
       const expectedOutput
@@ -48,7 +48,7 @@ describe('njkFilters', () => {
       expect(titleEnhanceFilter(input)).toEqual(expectedOutput);
     });
 
-    test('should not add empty strings to the title', () => {
+    test('should not an empty string to the title', () => {
       const titleEnhanceFilter = env.getFilter('titleEnhancer');
       const input = '';
       const expectedOutput
@@ -63,6 +63,24 @@ describe('njkFilters', () => {
         = 'Find a Court or Tribunal Admin Service – GOV.UK';
 
       expect(titleEnhanceFilter(testCase)).toEqual(expectedOutput);
+    });
+
+    test('should not have empty space wrapping the title', () => {
+      const titleEnhanceFilter = env.getFilter('titleEnhancer');
+      const input = ' Edit A List ';
+      const expectedOutput
+        = 'Edit A List - Find a Court or Tribunal Admin Service – GOV.UK';
+
+      expect(titleEnhanceFilter(input)).toEqual(expectedOutput);
+    });
+
+    test('should add string to title even if it has dashes', () => {
+      const titleEnhanceFilter = env.getFilter('titleEnhancer');
+      const input = 'I - have - dash';
+      const expectedOutput
+        = 'I - have - dash - Find a Court or Tribunal Admin Service – GOV.UK';
+
+      expect(titleEnhanceFilter(input)).toEqual(expectedOutput);
     });
   });
 });


### PR DESCRIPTION
### JIRA link ###

https://tools.hmcts.net/jira/browse/FACT-2203

### Change description ###

- Creates a nunjucks filter that takes a string or a list of strings and adds the service/department to the string
- Adds using the above filter for titles on the pages
- Unit tests for new filters
- Changes the functional tests to pass information that is now part of the title e.g. the name of the court on the edit court page
- Moves the existing filters to a njkfilters file
- Adds condition for title so that 'Edit Court' only shows for non-viewers and 'Details' shows for viewers in page titles 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
