### PR TITLE
FACT-2208 - Removes scrollbar

### DIFF
--- a/src/main/views/courts/addNewCourt.njk
+++ b/src/main/views/courts/addNewCourt.njk
@@ -151,7 +151,7 @@
           Please specify the service areas of the service centre
         </div>
 
-        <div id="serviceAreasList" class="visible-scrollbar scrollable" role="scrollbar"
+        <div id="serviceAreasList"
             aria-controls="casesHearCheckboxes" aria-orientation="vertical">
           {% if formErrors.serviceAreaError.text%}
             {% set serviceAreaErrorDesc = formErrors.serviceAreaError.text %}

--- a/src/main/views/courts/tabs/addressesContent.njk
+++ b/src/main/views/courts/tabs/addressesContent.njk
@@ -231,7 +231,7 @@
     have a write to address that only applies for Civil cases"})
   }}
 
-  <div class="govuk-grid-row scrollable visible-scrollbar role: scrollbar">
+  <div class="govuk-grid-row">
 
 {% set secondaryAddressAOLItems =  "secondaryAddressAOLItems"+ (loop.index - 1)%}
 
@@ -259,7 +259,7 @@
     have a write to address that only applies for Family courts"})
   }}
 
-  <div class="govuk-grid-row scrollable visible-scrollbar role: scrollbar">
+  <div class="govuk-grid-row">
 
 {% set secondaryAddressCourtItems = "secondaryAddressCourtItems"+ (loop.index - 1)%}
 

--- a/src/main/views/courts/tabs/casesHeardContent.njk
+++ b/src/main/views/courts/tabs/casesHeardContent.njk
@@ -43,7 +43,7 @@
       }), allAreasOfLawItems) %}
   {% endfor %}
 
-  <div id="casesHeardList" class="visible-scrollbar scrollable" role="scrollbar"
+  <div id="casesHeardList"
     aria-controls="casesHearCheckboxes"
     aria-orientation="vertical"
   >

--- a/src/main/views/courts/tabs/postcodesContent.njk
+++ b/src/main/views/courts/tabs/postcodesContent.njk
@@ -55,9 +55,9 @@
         'id': postcode, 'checked': true, 'disabled': true}), postcodesCheckboxItems) %}
     {% endfor %}
 
-    <div id="postcodesList" class="govuk-grid-row visible-scrollbar scrollable", role="scrollbar">
-      {%- for items in postcodesCheckboxItems | sort(false,true,'text') | slice(2) %}
-        <div class="govuk-grid-column-one-half">
+    <div id="postcodesList" class="govuk-grid-row">
+      {%- for items in postcodesCheckboxItems | sort(false,true,'text') | slice(3) %}
+        <div class="govuk-grid-column-one-third">
             {{ govukCheckboxes({
               idPrefix: "postcodes-checkbox",
               name: "postcodesCheckboxItems",
@@ -128,9 +128,9 @@
       }) }}
     </div>
 
-    <div id="postcodesList" class="govuk-grid-row visible-scrollbar scrollable", role="scrollbar">
-      {%- for items in postcodesCheckboxItems | sort(false,true,'text') | slice(2) %}
-        <div class="govuk-grid-column-one-half">
+    <div id="postcodesList" class="govuk-grid-row">
+      {%- for items in postcodesCheckboxItems | sort(false,true,'text') | slice(3) %}
+        <div class="govuk-grid-column-one-third">
             {{ govukCheckboxes({
               idPrefix: "postcodes-checkbox",
               name: "postcodesCheckboxItems",


### PR DESCRIPTION
### JIRA link ###

https://tools.hmcts.net/jira/browse/FACT-2208

### Change description ###

Removes the scrollbar from:
- The service areas on the add a new court form
- The cases heard tab
- The postcodes tab (and the postcodes put into three columns instead of 2)
- The areas of law on the addresses tab

**Note:** The scrollbar in the local authorities tab hasn't been removed as there are too many local authorities and removing makes the page very long.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
